### PR TITLE
Limit Number of Bookmarked PlaceGuides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
+                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
@@ -31,6 +31,12 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
     REMOVE
   }
 
+  /**
+   * Performs the bookmarking/unbookmarking if it's allowed. If it was succesfully executed, the
+   * servlet returns true. Otherwise it returns false. Remark that an operation is not allowed if
+   * the user wants to bookmark a placeguide whereas they have already reached the maximum number of
+   * bookmarked placeguides.
+   */
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     long placeGuideId = Long.parseLong(request.getParameter(PLACE_GUIDE_ID_PARAMETER));
@@ -47,7 +53,7 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
    * placeGuideId by the cuurent user. If the user unbookmarked a placeguide, it will for sure
    * succeed. if the user bookmarked a placeguide, then the operation will succeed only if the user
    * didn't reach the limit for the maximum number of bookmarked placeguides before. The function
-   * returns true if the operation succeded, and false otherwise.
+   * returns true if the operation succeeded, and false otherwise.
    */
   private boolean togglePlaceGuideBookmark(
       BookmarkPlaceGuideQueryType bookmarkPlaceGuideQueryType, long placeGuideId) {

--- a/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
@@ -63,13 +63,12 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
         User user = userRepository.getUser(userId);
         if (user == null) {
           throw new IllegalStateException("The current user does not exist in the database!");
+        }
+        if (user.canBookmarkAnotherPlaceGuide()) {
+          userRepository.bookmarkPlaceGuide(placeGuideId, userId);
+          return true;
         } else {
-          if (user.canBookmarkAnotherPlaceGuide()) {
-            userRepository.bookmarkPlaceGuide(placeGuideId, userId);
-            return true;
-          } else {
-            return false;
-          }
+          return false;
         }
       case UNBOOKMARK:
         userRepository.removeBookmarkedPlaceGuide(placeGuideId, userId);

--- a/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
@@ -2,6 +2,7 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.datastore.*;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
 import com.google.sps.data.RepositoryType;
 import com.google.sps.user.User;
 import com.google.sps.user.repository.UserRepository;
@@ -36,7 +37,9 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
     String bookmarkHandlingType = request.getParameter(BOOKMARK_HANDLING_TYPE_PARAMETER);
     BookmarkPlaceGuideQueryType queryType =
         BookmarkPlaceGuideQueryType.valueOf(bookmarkHandlingType);
-    togglePlaceGuideBookmark(queryType, placeGuideId);
+    boolean actionSucceded = togglePlaceGuideBookmark(queryType, placeGuideId);
+    response.setContentType("application/json;");
+    response.getWriter().println(convertToJsonUsingGson(Boolean.valueOf(actionSucceded)));
   }
 
   /**
@@ -68,5 +71,11 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
       default:
         throw new IllegalStateException("Bookmark handling type does not exist!");
     }
+  }
+
+  private String convertToJsonUsingGson(Object o) {
+    Gson gson = new Gson();
+    String json = gson.toJson(o);
+    return json;
   }
 }

--- a/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
@@ -32,7 +32,7 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
   }
 
   /**
-   * Performs the bookmarking/unbookmarking if it's allowed. If it was succesfully executed, the
+   * Performs the bookmarking/unbookmarking if it's allowed. If it was successfully executed, the
    * servlet returns true. Otherwise it returns false. Remark that an operation is not allowed if
    * the user wants to bookmark a placeguide whereas they have already reached the maximum number of
    * bookmarked placeguides.

--- a/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
@@ -39,6 +39,13 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
     togglePlaceGuideBookmark(queryType, placeGuideId);
   }
 
+  /**
+   * This functions handles the bookmarking/unbookmarking of the placeguide with id = @param
+   * placeGuideId by the cuurent user. If the user unbookmarked a placeguide, it will for sure
+   * succeed. if the user bookmarked a placeguide, then the operation will succeed only if the user
+   * didn't reach the limit for the maximum number of bookmarked placeguides before. The function
+   * returns true if the operation succeded, and false otherwise.
+   */
   private boolean togglePlaceGuideBookmark(
       BookmarkPlaceGuideQueryType bookmarkPlaceGuideQueryType, long placeGuideId) {
     String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();

--- a/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
@@ -20,8 +20,8 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/bookmark-place-guide")
 public class BookmarkPlaceGuideServlet extends HttpServlet {
 
-  private static final String PLACE_GUIDE_ID_PARAMETER = "placeGuideId";
-  private static final String BOOKMARK_HANDLING_TYPE_PARAMETER = "bookmarkHandlingType";
+  public static final String PLACE_GUIDE_ID_PARAMETER = "placeGuideId";
+  public static final String BOOKMARK_HANDLING_TYPE_PARAMETER = "bookmarkHandlingType";
 
   private final UserRepository userRepository =
       UserRepositoryFactory.getUserRepository(RepositoryType.DATASTORE);

--- a/src/main/java/com/google/sps/user/User.java
+++ b/src/main/java/com/google/sps/user/User.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 /** Stores the data related to one user. */
 public class User {
+  private static final int MAX_NO_BOOKMARKED_PLACEGUIDES = 25;
   private final String id;
   private final String email;
   private final boolean publicPortfolio;
@@ -124,6 +125,10 @@ public class User {
 
   public Set<Long> getBookmarkedPlaceGuidesIds() {
     return Collections.unmodifiableSet(bookmarkedPlaceGuidesIds);
+  }
+
+  public boolean canBookmarkAnotherPlaceGuide() {
+    return this.bookmarkedPlaceGuidesIds.size() < MAX_NO_BOOKMARKED_PLACEGUIDES;
   }
 
   @Override

--- a/src/main/webapp/placeGuides/ListPlaceGuideDisplayer.js
+++ b/src/main/webapp/placeGuides/ListPlaceGuideDisplayer.js
@@ -60,6 +60,14 @@ class ListPlaceGuideDisplayer {
     this.addPlaceGuidesToList(placeGuidesCopy);
   }
 
+  bookmark(placeGuideId) {
+    PlaceGuideOnList.bookmark(placeGuideId);
+  }
+
+  unbookmark(placeGuideId) {
+    PlaceGuideOnList.unbookmark(placeGuideId);
+  }
+
   extractIdFromDivId(placeGuideDivId) {
     return Number(placeGuideDivId.slice(18, placeGuideDivId.length - 1));
   }

--- a/src/main/webapp/placeGuides/PlaceGuideManager.js
+++ b/src/main/webapp/placeGuides/PlaceGuideManager.js
@@ -10,22 +10,22 @@ class PlaceGuideManager {
   static PAGE = {
     DISCOVER: {
       query: PlaceGuideRepository.QUERY_TYPE.ALL_PUBLIC_IN_MAP_AREA,
-      onGuideBookmarkStatusChanged: undefined,
+      onGuideBookmarkStatusChanged: PlaceGuideManager.toogleBookmarkIcon,
       name: "DISCOVER"
     },
     MY_GUIDES: {
       query: PlaceGuideRepository.QUERY_TYPE.CREATED_ALL_IN_MAP_AREA,
-      onGuideBookmarkStatusChanged: undefined,
+      onGuideBookmarkStatusChanged: PlaceGuideManager.toogleBookmarkIcon,
       name: "MY_GUIDES"
     },
     CREATE_PLACE_GUIDE: {
       query: PlaceGuideRepository.QUERY_TYPE.CREATED_ALL_IN_MAP_AREA,
-      onGuideBookmarkStatusChanged: undefined,
+      onGuideBookmarkStatusChanged: PlaceGuideManager.toogleBookmarkIcon,
       name: "CREATE_PLACE_GUIDE"
     },
     BOOKMARKED_PLACEGUIDES: {
       query: PlaceGuideRepository.QUERY_TYPE.BOOKMARKED,
-      onGuideBookmarkStatusChanged: PlaceGuideManager.removeGuideIfUnbookmarked,
+      onGuideBookmarkStatusChanged: PlaceGuideManager.removeGuideIfUnbookmarked_elseToogleIcon,
       name: "BOOKMARKED_PLACEGUIDES"
     },
   };
@@ -91,11 +91,11 @@ class PlaceGuideManager {
   toggleBookmark(placeGuideId) {
     this._placeGuideRepository.togglePlaceGuideBookmarkStatus(placeGuideId)
       .then((response) => {
-        if(response == PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SUCCESS) {
+        if(response === PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SUCCESS) {
           if (this._page.onGuideBookmarkStatusChanged != undefined) {
             this._page.onGuideBookmarkStatusChanged(this, placeGuideId);
           }
-        } else if(response == PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SUCCESS) {
+        } else if(response === PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.NOT_ALLOWED) {
           alert(`You can't bookmark more than ${MAX_NO_BOOKMARKED_GUIDES} gudies. Please unbookmark some of them before bookmarking a new one`);
         } else {
           alert("Failed to execute bookmarking/unbookmarking");
@@ -103,9 +103,27 @@ class PlaceGuideManager {
       });
   }
 
-  static removeGuideIfUnbookmarked(placeGuideManager, placeGuideId) {
-    if(!placeGuideManager._placeGuideRepository.isBookmarked(placeGuideId)) {
+  static removeGuideIfUnbookmarked_elseToogleIcon(placeGuideManager, placeGuideId) {
+    if (!placeGuideManager._placeGuideRepository.isBookmarked(placeGuideId)) {
+      placeGuideManager.setBookmarked(placeGuideId);
+    } else {
       placeGuideManager.removePlaceGuideRepresentation(placeGuideId);
     }
+  }
+
+  static toogleBookmarkIcon(placeGuideManager, placeGuideId) {
+    if (placeGuideManager._placeGuideRepository.isBookmarked(placeGuideId)) {
+      placeGuideManager.setBookmarked(placeGuideId);
+    } else {
+      placeGuideManager.setUnBookmarked((placeGuideId));
+    }
+  }
+
+  setBookmarked(placeGuideId) {
+    this._listPlaceGuideDisplayer.bookmark(placeGuideId);
+  }
+
+  setUnBookmarked(placeGuideId) {
+    this._listPlaceGuideDisplayer.unbookmark(placeGuideId);
   }
 }

--- a/src/main/webapp/placeGuides/PlaceGuideManager.js
+++ b/src/main/webapp/placeGuides/PlaceGuideManager.js
@@ -25,7 +25,7 @@ class PlaceGuideManager {
     },
     BOOKMARKED_PLACEGUIDES: {
       query: PlaceGuideRepository.QUERY_TYPE.BOOKMARKED,
-      onGuideBookmarkStatusChanged: PlaceGuideManager.removeGuideIfUnbookmarked_elseToogleIcon,
+      onGuideBookmarkStatusChanged: PlaceGuideManager.removeGuideIfUnbookmarked,
       name: "BOOKMARKED_PLACEGUIDES"
     },
   };
@@ -96,17 +96,15 @@ class PlaceGuideManager {
             this._page.onGuideBookmarkStatusChanged(this, placeGuideId);
           }
         } else if(response === PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.NOT_ALLOWED) {
-          alert(`You can't bookmark more than ${MAX_NO_BOOKMARKED_GUIDES} gudies. Please unbookmark some of them before bookmarking a new one`);
+          alert(`You can't bookmark more than ${PlaceGuideManager.MAX_NO_BOOKMARKED_GUIDES} gudies. Please unbookmark some of them before bookmarking a new one`);
         } else {
           alert("Failed to execute bookmarking/unbookmarking");
         }
       });
   }
 
-  static removeGuideIfUnbookmarked_elseToogleIcon(placeGuideManager, placeGuideId) {
+  static removeGuideIfUnbookmarked(placeGuideManager, placeGuideId) {
     if (!placeGuideManager._placeGuideRepository.isBookmarked(placeGuideId)) {
-      placeGuideManager.setBookmarked(placeGuideId);
-    } else {
       placeGuideManager.removePlaceGuideRepresentation(placeGuideId);
     }
   }

--- a/src/main/webapp/placeGuides/PlaceGuideManager.js
+++ b/src/main/webapp/placeGuides/PlaceGuideManager.js
@@ -6,6 +6,7 @@
  * executing it(PlaceGudieRepository, Map- and ListPlaceGuideDisplayer).
  */
 class PlaceGuideManager {
+  static MAX_NO_BOOKMARKED_GUIDES = 25;
   static PAGE = {
     DISCOVER: {
       query: PlaceGuideRepository.QUERY_TYPE.ALL_PUBLIC_IN_MAP_AREA,
@@ -86,10 +87,14 @@ class PlaceGuideManager {
   toggleBookmark(placeGuideId) {
     this._placeGuideRepository.togglePlaceGuideBookmarkStatus(placeGuideId)
       .then((response) => {
-        if(response) {
-          if (this._page.guideBookmarkStatusChanged != undefined) {
+        if(response == PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SUCCESS) {
+          if (this._page.onGuideBookmarkStatusChanged != undefined) {
             this._page.onGuideBookmarkStatusChanged(this, placeGuideId);
           }
+        } else if(response == PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SUCCESS) {
+          alert(`You can't bookmark more than ${MAX_NO_BOOKMARKED_GUIDES} gudies. Please unbookmark some of them before bookmarking a new one`);
+        } else {
+          alert("Failed to execute bookmarking/unbookmarking");
         }
       });
   }

--- a/src/main/webapp/placeGuides/PlaceGuideManager.js
+++ b/src/main/webapp/placeGuides/PlaceGuideManager.js
@@ -9,19 +9,19 @@ class PlaceGuideManager {
   static PAGE = {
     DISCOVER: {
       query: PlaceGuideRepository.QUERY_TYPE.ALL_PUBLIC_IN_MAP_AREA,
-      guideBookmarkStatusChanged: undefined,
+      onGuideBookmarkStatusChanged: undefined,
     },
     MY_GUIDES: {
       query: PlaceGuideRepository.QUERY_TYPE.CREATED_ALL_IN_MAP_AREA,
-      guideBookmarkStatusChanged: undefined,
+      onGuideBookmarkStatusChanged: undefined,
     },
     CREATE_PLACE_GUIDE: {
       query: PlaceGuideRepository.QUERY_TYPE.CREATED_ALL_IN_MAP_AREA,
-      guideBookmarkStatusChanged: undefined,
+      onGuideBookmarkStatusChanged: undefined,
     },
     BOOKMARKED_PLACEGUIDES: {
       query: PlaceGuideRepository.QUERY_TYPE.BOOKMARKED,
-      guideBookmarkStatusChanged: PlaceGuideManager.removeGuideIfUnbookmarked,
+      onGuideBookmarkStatusChanged: PlaceGuideManager.removeGuideIfUnbookmarked,
     }
   };
 
@@ -88,7 +88,7 @@ class PlaceGuideManager {
       .then((response) => {
         if(response) {
           if (this._page.guideBookmarkStatusChanged != undefined) {
-            this._page.guideBookmarkStatusChanged(this, placeGuideId);
+            this._page.onGuideBookmarkStatusChanged(this, placeGuideId);
           }
         }
       });

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -37,13 +37,15 @@ class PlaceGuideOnList {
   }
 
   static bookmark(placeGuideId) {
-    const bookmarkButton = document.getElementById(PlaceGuideOnList.bookmarkButtonId(placeGuideId));
+    const bookmarkButton = document
+        .getElementById(PlaceGuideOnList.bookmarkButtonId(placeGuideId));
     bookmarkButton.innerText = 'bookmark';
     bookmarkButton.setAttribute('title', 'unbookmark place guide');
   }
 
   static unbookmark(placeGuideId) {
-    const bookmarkButton = document.getElementById(PlaceGuideOnList.bookmarkButtonId(placeGuideId));
+    const bookmarkButton = document
+        .getElementById(PlaceGuideOnList.bookmarkButtonId(placeGuideId));
     bookmarkButton.innerText = 'bookmark_border';
     bookmarkButton.setAttribute('title', 'bookmark place guide');
   }
@@ -387,7 +389,8 @@ class PlaceGuideOnList {
 
   createBookmarkButton(placeGuideId, bookmarkedByCurrentUser, parentDiv) {
     const bookmarkButton = this.getPlaceGuideButtonWithPreparedClasses();
-    bookmarkButton.setAttribute("id", PlaceGuideOnList.bookmarkButtonId(placeGuideId));
+    bookmarkButton.setAttribute("id",
+        PlaceGuideOnList.bookmarkButtonId(placeGuideId));
     bookmarkButton.setAttribute('title', 'bookmark place guide');
     bookmarkButton.innerText = 'bookmark_border';
     if (bookmarkedByCurrentUser) {

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -36,6 +36,18 @@ class PlaceGuideOnList {
     PlaceGuideOnList.close(placeGuideId);
   }
 
+  static bookmark(placeGuideId) {
+    const bookmarkButton = document.getElementById(PlaceGuideOnList.bookmarkButtonId(placeGuideId));
+    bookmarkButton.innerText = 'bookmark';
+    bookmarkButton.setAttribute('title', 'unbookmark place guide');
+  }
+
+  static unbookmark(placeGuideId) {
+    const bookmarkButton = document.getElementById(PlaceGuideOnList.bookmarkButtonId(placeGuideId));
+    bookmarkButton.innerText = 'bookmark_border';
+    bookmarkButton.setAttribute('title', 'bookmark place guide');
+  }
+
   createPlaceGuideOnListDiv(
       placeGuideProperties,
       creator,
@@ -375,6 +387,7 @@ class PlaceGuideOnList {
 
   createBookmarkButton(placeGuideId, bookmarkedByCurrentUser, parentDiv) {
     const bookmarkButton = this.getPlaceGuideButtonWithPreparedClasses();
+    bookmarkButton.setAttribute("id", PlaceGuideOnList.bookmarkButtonId(placeGuideId));
     bookmarkButton.setAttribute('title', 'bookmark place guide');
     bookmarkButton.innerText = 'bookmark_border';
     if (bookmarkedByCurrentUser) {
@@ -382,13 +395,6 @@ class PlaceGuideOnList {
       bookmarkButton.setAttribute('title', 'unbookmark place guide');
     }
     bookmarkButton.addEventListener('click', function() {
-      if (bookmarkButton.innerText == 'bookmark') {
-        bookmarkButton.innerText = 'bookmark_border';
-        bookmarkButton.setAttribute('title', 'bookmark place guide');
-      } else {
-        bookmarkButton.innerText = 'bookmark';
-        bookmarkButton.setAttribute('title', 'unbookmark place guide');
-      }
       placeGuideManager.toggleBookmark(placeGuideId);
     });
     parentDiv.appendChild(bookmarkButton);
@@ -421,5 +427,9 @@ class PlaceGuideOnList {
     placeGuideDiv.querySelectorAll('.folded-placeGuide')[0].style.display = 'block';
     placeGuideDiv.querySelectorAll('.card-placeGuide')[0].style.display = 'none';
     placeGuideDiv.style.removeProperty('padding');
+  }
+
+  static bookmarkButtonId(placeGuideId) {
+    return `bookmarkBtn-${placeGuideId}`;
   }
 }

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -13,6 +13,12 @@ class PlaceGuideRepository {
     BOOKMARKED: "BOOKMARKED",
   };
 
+  static BOOKMARK_ACTION_RESULT_TYPE = {
+      SUCCESS = {},
+      NOT_ALLOWED = {},
+      SERVER_FAILURE = {},
+  }
+
   constructor() {
     this._placeGuides = {};
   }
@@ -177,12 +183,22 @@ class PlaceGuideRepository {
           console.log("BookmarkPlaceGuideServlet: failed to fetch: "
             + error);
           alert("Failed to execute bookmarking/unbookmarking");
-          resolve(false);
+          resolve(PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SERVER_FAILURE);
+        })
+        .then(response => response.json())
+        .catch(error => {
+            console.log('updatePlaceGuides: failed to convert response to JSON'
+                  + error);
+            alert("Failed to process the response from the server");
         })
         .then(response => {
-          // Toggle in in-memory dictionary.
-          resolve(true);
-          thisRepository._placeGuides[placeGuideId].bookmarkedByCurrentUser = !isBookmarked;
+          if (response) {
+            thisRepository._placeGuides[placeGuideId].bookmarkedByCurrentUser = !isBookmarked;
+            // Toggle in in-memory dictionary.
+            resolve(PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SUCCESS);
+          } else{
+            resolve(PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.NOT_ALLOWED);
+          }
         });
     });
   }

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -14,9 +14,9 @@ class PlaceGuideRepository {
   };
 
   static BOOKMARK_ACTION_RESULT_TYPE = {
-      SUCCESS = {},
-      NOT_ALLOWED = {},
-      SERVER_FAILURE = {},
+      SUCCESS: {},
+      NOT_ALLOWED: {},
+      SERVER_FAILURE: {},
   }
 
   constructor() {
@@ -182,7 +182,6 @@ class PlaceGuideRepository {
         .catch(error => {
           console.log("BookmarkPlaceGuideServlet: failed to fetch: "
             + error);
-          alert("Failed to execute bookmarking/unbookmarking");
           resolve(PlaceGuideRepository.BOOKMARK_ACTION_RESULT_TYPE.SERVER_FAILURE);
         })
         .then(response => response.json())

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+import com.google.appengine.api.datastore.*;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import java.util.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class BookmarkPlaceGuideServletTest {
+  private Map<String, Object> attributeToValue = new HashMap<>();
+  private LocalServiceTestHelper helper;
+
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+
+  @Before
+  public void setup() {
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+}

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -131,23 +131,15 @@ public final class BookmarkPlaceGuideServletTest {
   private static final String EMAIL = "user@gmail.com";
   private static final Set<Long> EMPTY_BOOKMARKED_PLACE_GUIDES_IDS = null;
   private static final Set<Long> BOOKMARKED_PLACE_GUIDES_IDS_A =
-      new HashSet<>(
-          Arrays.asList(
-              (long) 1, (long) 2, (long) 3, (long) 4, (long) 5, (long) 6, (long) 7, (long) 8,
-              (long) 9, (long) 10));
+      new HashSet<>(Arrays.asList(1l, 2l, 3l, 4l, 5l, 6l, 7l, 8l, 9l, 10l));
   private static final Set<Long> BOOKMARKED_PLACE_GUIDES_IDS_B =
       new HashSet<>(
           Arrays.asList(
-              (long) 1, (long) 2, (long) 3, (long) 4, (long) 5, (long) 6, (long) 7, (long) 8,
-              (long) 9, (long) 10, (long) 11, (long) 12, (long) 13, (long) 14, (long) 15, (long) 16,
-              (long) 17, (long) 18, (long) 19, (long) 20, (long) 21, (long) 22, (long) 23,
-              (long) 24, (long) 25));
+              1l, 2l, 3l, 4l, 5l, 6l, 7l, 8l, 9l, 10l, 11l, 12l, 13l, 14l, 15l, 16l, 17l, 18l, 19l,
+              20l, 21l, 22l, 23l, 24l, 25l));
   private static final Set<Long> BOOKMARKED_PLACE_GUIDES_IDS_C =
       new HashSet<>(
-          Arrays.asList(
-              (long) 1, (long) 2, (long) 3, (long) 4, (long) 5, (long) 6, (long) 7, (long) 8,
-              (long) 9, (long) 10, (long) 11, (long) 12, (long) 13, (long) 14, (long) 15,
-              (long) 26));
+          Arrays.asList(1l, 2l, 3l, 4l, 5l, 6l, 7l, 8l, 9l, 10l, 11l, 12l, 13l, 14l, 15l, 26l));
   private static final String NAME = "username";
   private static final String SELF_INTRODUCTION = "I am the user";
   private static final String IMG_KEY = "/img.com";

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -159,15 +159,12 @@ public final class BookmarkPlaceGuideServletTest {
 
   @Before
   public void setup() {
-    attributeToValue.put("com.google.appengine.api.users.UserService.user_id_key", (Object) ID_A);
     helper =
         new LocalServiceTestHelper(
                 new LocalDatastoreServiceTestConfig(), new LocalBlobstoreServiceTestConfig())
             .setEnvIsLoggedIn(true)
             .setEnvAuthDomain("localhost")
-            .setEnvEmail(EMAIL)
-            .setEnvAttributes(attributeToValue);
-    helper.setUp();
+            .setEnvEmail(EMAIL);
 
     request = mock(HttpServletRequest.class);
     response = mock(HttpServletResponse.class);
@@ -231,6 +228,10 @@ public final class BookmarkPlaceGuideServletTest {
   @Test
   public void doPost_bookmark_bookmarkingLimitNotExceeded_succesfulBookmarking()
       throws IOException, EntityNotFoundException {
+    attributeToValue.clear();
+    attributeToValue.put("com.google.appengine.api.users.UserService.user_id_key", (Object) ID_A);
+    helper.setEnvAttributes(attributeToValue);
+    helper.setUp();
     saveUser(userA);
     savePlaceGuide(toBookmarkGuide);
     setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
@@ -241,6 +242,21 @@ public final class BookmarkPlaceGuideServletTest {
     Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
     assertTrue(successfulBookmark);
     assertTrue(userHasBookmarkedThePlaceGuide(ID_A, toBookmarkGuide.getId()));
+  }
+
+  @Test
+  public void doPost_bookmark_bookmarkingLimitExceeded_succesfulBookmarking()
+      throws IOException, EntityNotFoundException {
+    // saveUser(userB);
+    // savePlaceGuide(toBookmarkGuide);
+    // setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
+    // BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
+    // boookmarkPlaceGuideServlet.doPost(request, response);
+    // pw.flush();
+    // Gson gson = new Gson();
+    // Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
+    // assertFalse(successfulBookmark);
+    // assertFalse(userHasBookmarkedThePlaceGuide(ID_B, toBookmarkGuide.getId()));
   }
 
   @After

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -66,7 +66,8 @@ public final class BookmarkPlaceGuideServletTest {
           Arrays.asList(
               (long) 1, (long) 2, (long) 3, (long) 4, (long) 5, (long) 6, (long) 7, (long) 8,
               (long) 9, (long) 10, (long) 11, (long) 12, (long) 13, (long) 14, (long) 15, (long) 16,
-              (long) 17, (long) 18, (long) 19, (long) 20));
+              (long) 17, (long) 18, (long) 19, (long) 20, (long) 21, (long) 22, (long) 23,
+              (long) 24, (long) 25));
   private static final String NAME = "username";
   private static final String SELF_INTRODUCTION = "I am the user";
   private static final String IMG_KEY = "/img.com";
@@ -90,7 +91,7 @@ public final class BookmarkPlaceGuideServletTest {
           .build();
 
   // PlaceGuides data
-  private static final long PLACEGUIDE_ID = 21;
+  private static final long PLACEGUIDE_ID = 26;
   private static final String PLACEGUIDE_NAME = "name";
   private static final String AUDIO_KEY = "audioKey";
   private static final String PLACE_ID = "placeId";
@@ -245,18 +246,23 @@ public final class BookmarkPlaceGuideServletTest {
   }
 
   @Test
-  public void doPost_bookmark_bookmarkingLimitExceeded_succesfulBookmarking()
+  public void doPost_bookmark_bookmarkingLimitExceeded_unsuccesfulBookmarking()
       throws IOException, EntityNotFoundException {
-    // saveUser(userB);
-    // savePlaceGuide(toBookmarkGuide);
-    // setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
-    // BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
-    // boookmarkPlaceGuideServlet.doPost(request, response);
-    // pw.flush();
-    // Gson gson = new Gson();
-    // Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
-    // assertFalse(successfulBookmark);
-    // assertFalse(userHasBookmarkedThePlaceGuide(ID_B, toBookmarkGuide.getId()));
+    attributeToValue.clear();
+    attributeToValue.put("com.google.appengine.api.users.UserService.user_id_key", (Object) ID_B);
+    helper.setEnvAttributes(attributeToValue);
+    helper.setUp();
+    saveUser(userB);
+    savePlaceGuide(toBookmarkGuide);
+    System.out.println("!!!B can bookmark another guide: " + userB.canBookmarkAnotherPlaceGuide());
+    setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
+    BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
+    boookmarkPlaceGuideServlet.doPost(request, response);
+    pw.flush();
+    Gson gson = new Gson();
+    Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
+    assertFalse(successfulBookmark);
+    assertFalse(userHasBookmarkedThePlaceGuide(ID_B, toBookmarkGuide.getId()));
   }
 
   @After

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -86,7 +86,6 @@ public final class BookmarkPlaceGuideServletTest {
     setupCurrentUserIdInHelper(ID_B);
     saveUser(userB);
     savePlaceGuide(toBookmarkGuide);
-    System.out.println("!!!B can bookmark another guide: " + userB.canBookmarkAnotherPlaceGuide());
     setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
     BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
     boookmarkPlaceGuideServlet.doGet(request, response);
@@ -103,7 +102,6 @@ public final class BookmarkPlaceGuideServletTest {
     setupCurrentUserIdInHelper(ID_C);
     saveUser(userC);
     savePlaceGuide(toBookmarkGuide);
-    System.out.println("!!!B can bookmark another guide: " + userB.canBookmarkAnotherPlaceGuide());
     setupRequestandResponse("Unbookmark", toBookmarkGuide.getId());
     BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
     boookmarkPlaceGuideServlet.doGet(request, response);

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -54,6 +54,7 @@ public final class BookmarkPlaceGuideServletTest {
   // Users data.
   private static final String ID_A = "useridA";
   private static final String ID_B = "useridB";
+  private static final String ID_C = "useridC";
   private static final String EMAIL = "user@gmail.com";
   private static final Set<Long> EMPTY_BOOKMARKED_PLACE_GUIDES_IDS = null;
   private static final Set<Long> BOOKMARKED_PLACE_GUIDES_IDS_A =
@@ -68,6 +69,12 @@ public final class BookmarkPlaceGuideServletTest {
               (long) 9, (long) 10, (long) 11, (long) 12, (long) 13, (long) 14, (long) 15, (long) 16,
               (long) 17, (long) 18, (long) 19, (long) 20, (long) 21, (long) 22, (long) 23,
               (long) 24, (long) 25));
+  private static final Set<Long> BOOKMARKED_PLACE_GUIDES_IDS_C =
+      new HashSet<>(
+          Arrays.asList(
+              (long) 1, (long) 2, (long) 3, (long) 4, (long) 5, (long) 6, (long) 7, (long) 8,
+              (long) 9, (long) 10, (long) 11, (long) 12, (long) 13, (long) 14, (long) 15,
+              (long) 26));
   private static final String NAME = "username";
   private static final String SELF_INTRODUCTION = "I am the user";
   private static final String IMG_KEY = "/img.com";
@@ -84,6 +91,15 @@ public final class BookmarkPlaceGuideServletTest {
   private final User userB =
       new User.Builder(ID_B, EMAIL)
           .setBookmarkedPlaceGuidesIds(BOOKMARKED_PLACE_GUIDES_IDS_B)
+          .setName(NAME)
+          .setPublicPortfolio(true)
+          .addSelfIntroduction(SELF_INTRODUCTION)
+          .addImgKey(IMG_KEY)
+          .build();
+
+  private final User userC =
+      new User.Builder(ID_C, EMAIL)
+          .setBookmarkedPlaceGuidesIds(BOOKMARKED_PLACE_GUIDES_IDS_C)
           .setName(NAME)
           .setPublicPortfolio(true)
           .addSelfIntroduction(SELF_INTRODUCTION)
@@ -263,6 +279,26 @@ public final class BookmarkPlaceGuideServletTest {
     Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
     assertFalse(successfulBookmark);
     assertFalse(userHasBookmarkedThePlaceGuide(ID_B, toBookmarkGuide.getId()));
+  }
+
+  @Test
+  public void doPost_unbookmark_succesfulUnbookmarking()
+      throws IOException, EntityNotFoundException {
+    attributeToValue.clear();
+    attributeToValue.put("com.google.appengine.api.users.UserService.user_id_key", (Object) ID_C);
+    helper.setEnvAttributes(attributeToValue);
+    helper.setUp();
+    saveUser(userC);
+    savePlaceGuide(toBookmarkGuide);
+    System.out.println("!!!B can bookmark another guide: " + userB.canBookmarkAnotherPlaceGuide());
+    setupRequestandResponse("Unbookmark", toBookmarkGuide.getId());
+    BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
+    boookmarkPlaceGuideServlet.doPost(request, response);
+    pw.flush();
+    Gson gson = new Gson();
+    Boolean successfulUnbookmark = gson.fromJson(sw.toString(), Boolean.class);
+    assertTrue(successfulUnbookmark);
+    assertFalse(userHasBookmarkedThePlaceGuide(ID_C, toBookmarkGuide.getId()));
   }
 
   @After

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.appengine.api.datastore.*;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.sps.user.User;
 import java.util.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -34,6 +35,43 @@ public final class BookmarkPlaceGuideServletTest {
 
   private HttpServletRequest request;
   private HttpServletResponse response;
+
+  private static final String ID_A = "useridA";
+  private static final String ID_B = "useridB";
+  private static final String EMAIL = "user@gmail.com";
+  private static final Set<Long> EMPTY_BOOKMARKED_PLACE_GUIDES_IDS = null;
+  private static final Set<Long> BOOKMARKED_PLACE_GUIDES_IDS_A =
+      new HashSet<>(
+          Arrays.asList(
+              (long) 1, (long) 2, (long) 3, (long) 4, (long) 5, (long) 6, (long) 7, (long) 8,
+              (long) 9, (long) 10));
+  private static final Set<Long> BOOKMARKED_PLACE_GUIDES_IDS_B =
+      new HashSet<>(
+          Arrays.asList(
+              (long) 1, (long) 2, (long) 3, (long) 4, (long) 5, (long) 6, (long) 7, (long) 8,
+              (long) 9, (long) 10, (long) 11, (long) 12, (long) 13, (long) 14, (long) 15, (long) 16,
+              (long) 17, (long) 18, (long) 19, (long) 20));
+  private static final String NAME = "username";
+  private static final String SELF_INTRODUCTION = "I am the user";
+  private static final String IMG_KEY = "/img.com";
+
+  private final User userA =
+      new User.Builder(ID_A, EMAIL)
+          .setBookmarkedPlaceGuidesIds(BOOKMARKED_PLACE_GUIDES_IDS_A)
+          .setName(NAME)
+          .setPublicPortfolio(true)
+          .addSelfIntroduction(SELF_INTRODUCTION)
+          .addImgKey(IMG_KEY)
+          .build();
+
+  private final User userB =
+      new User.Builder(ID_B, EMAIL)
+          .setBookmarkedPlaceGuidesIds(BOOKMARKED_PLACE_GUIDES_IDS_B)
+          .setName(NAME)
+          .setPublicPortfolio(true)
+          .addSelfIntroduction(SELF_INTRODUCTION)
+          .addImgKey(IMG_KEY)
+          .build();
 
   @Before
   public void setup() {

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -65,14 +65,14 @@ public final class BookmarkPlaceGuideServletTest {
   }
 
   @Test
-  public void doPost_bookmark_bookmarkingLimitNotExceeded_succesfulBookmarking()
+  public void doGet_bookmark_bookmarkingLimitNotExceeded_succesfulBookmarking()
       throws IOException, EntityNotFoundException {
     setupCurrentUserIdInHelper(ID_A);
     saveUser(userA);
     savePlaceGuide(toBookmarkGuide);
     setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
     BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
-    boookmarkPlaceGuideServlet.doPost(request, response);
+    boookmarkPlaceGuideServlet.doGet(request, response);
     pw.flush();
     Gson gson = new Gson();
     Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
@@ -81,7 +81,7 @@ public final class BookmarkPlaceGuideServletTest {
   }
 
   @Test
-  public void doPost_bookmark_bookmarkingLimitExceeded_unsuccesfulBookmarking()
+  public void doGet_bookmark_bookmarkingLimitExceeded_unsuccesfulBookmarking()
       throws IOException, EntityNotFoundException {
     setupCurrentUserIdInHelper(ID_B);
     saveUser(userB);
@@ -89,7 +89,7 @@ public final class BookmarkPlaceGuideServletTest {
     System.out.println("!!!B can bookmark another guide: " + userB.canBookmarkAnotherPlaceGuide());
     setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
     BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
-    boookmarkPlaceGuideServlet.doPost(request, response);
+    boookmarkPlaceGuideServlet.doGet(request, response);
     pw.flush();
     Gson gson = new Gson();
     Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
@@ -98,7 +98,7 @@ public final class BookmarkPlaceGuideServletTest {
   }
 
   @Test
-  public void doPost_unbookmark_succesfulUnbookmarking()
+  public void doGet_unbookmark_succesfulUnbookmarking()
       throws IOException, EntityNotFoundException {
     setupCurrentUserIdInHelper(ID_C);
     saveUser(userC);
@@ -106,7 +106,7 @@ public final class BookmarkPlaceGuideServletTest {
     System.out.println("!!!B can bookmark another guide: " + userB.canBookmarkAnotherPlaceGuide());
     setupRequestandResponse("Unbookmark", toBookmarkGuide.getId());
     BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
-    boookmarkPlaceGuideServlet.doPost(request, response);
+    boookmarkPlaceGuideServlet.doGet(request, response);
     pw.flush();
     Gson gson = new Gson();
     Boolean successfulUnbookmark = gson.fromJson(sw.toString(), Boolean.class);


### PR DESCRIPTION
### This PR contains the changes needed to limit the number of bookmarked placeguides to 25/user.

To achieve this goal, I applied the following changes:

#### Server Side 
- the User class has a field specifying the maximum number of bookmarked placeguides(currently set to 25) and a public function which specifies if a concrete user can bookmark one more placeguide
- The BookmarkPlaceGuideServlet checks in case of a bookmarking action if the current user can bookmark a new guide. The action is executed only if they can. The servlet returns true if the action was executed, and false, if it was not allowed.

#### Client Side
- the PlaceGuideRepository updates the local cache only if the servlet returned a positive result(i.e. the action was allowed)
- PlaceGuideRepository returns to placeGuideManager the status of the action, which can be success, not allowed or failed(server failure).
- PlaceGuideManager handles the status returned by PlaceGuideRepository: if the action completed successfully, it sends the necessary commands to the displayers to update the UI. Otherwise, a message will be displayed to the user.
- Only if the action was succesfully completed will the bookmark icon be changed. 

#### Tests
the tests of BookmarkPlaceGudieServlet were missing completely, so I implemented them all, taking into account the new changed. 