### PR TITLE
Geolocation Timeout

### DIFF
--- a/src/main/webapp/maps/Geolocator.js
+++ b/src/main/webapp/maps/Geolocator.js
@@ -68,7 +68,8 @@ class Geolocator {
 
   /**
    * This function tries to find the user's current location, and
-   * if it is found, it centers the map around it and sets 
+   * if it is found within 1 second,
+   * it centers the map around it and sets 
    * a higher zoom level.
    * If the location cannot be found, nothing happens.
    */

--- a/src/main/webapp/maps/Geolocator.js
+++ b/src/main/webapp/maps/Geolocator.js
@@ -78,7 +78,9 @@ class Geolocator {
        map.setZoom(10);
        map.setCenter(
         Geolocator.convertCurrentLocationToLatLng(position));
-      }
+      },
+      error => {},
+      {timeout:1000}
     );
   }
 
@@ -111,7 +113,7 @@ class Geolocator {
           error => {
             this._foundLocation = false;
             this._currentLocation.visible = false;
-            showError(error);
+            this.showError(error);
           }
       );
     } else {


### PR DESCRIPTION
### I set up a timeout of 1 second for the geolocator. 

#### Context
When the map is loaded on one page, I use navigator.geolocation to find the user's current location and center the map at that point. 

#### Issue
By default, the naviator.geoloctaion has an infinite timeout, so whenever the user's location is finally found, no matter how late it is, the map gets recentered. This may be annoying if the user already started taking actions(for example, if they already centered a map at another location in which they are interested).

#### Fix
I set a timeout so that the map gets recentered after the page is loaded only if the location is found within 1s. 