### PR TITLE
Bug Fix: unhighlighting inexistent placeguides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
-                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
+                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/src/main/webapp/placeGuides/MapPlaceGuideDisplayer.js
+++ b/src/main/webapp/placeGuides/MapPlaceGuideDisplayer.js
@@ -25,7 +25,7 @@ class MapPlaceGuideDisplayer {
   }
 
   unhighlight(placeGuideId) {
-    if( this._placeGuidesOnMap[placeGuideId] != undefined) {
+    if ( this._placeGuidesOnMap[placeGuideId] != undefined) {
       this._placeGuidesOnMap[placeGuideId].unhighlight();
     }
   }

--- a/src/main/webapp/placeGuides/MapPlaceGuideDisplayer.js
+++ b/src/main/webapp/placeGuides/MapPlaceGuideDisplayer.js
@@ -14,6 +14,8 @@ class MapPlaceGuideDisplayer {
   }
 
   remove(placeGuideId) {
+    this._markerClusterer.removeMarker(
+        this._placeGuidesOnMap[placeGuideId].marker);
     this._placeGuidesOnMap[placeGuideId].remove();
     delete this._placeGuidesOnMap[placeGuideId];
   }
@@ -23,7 +25,9 @@ class MapPlaceGuideDisplayer {
   }
 
   unhighlight(placeGuideId) {
-    this._placeGuidesOnMap[placeGuideId].unhighlight();
+    if( this._placeGuidesOnMap[placeGuideId] != undefined) {
+      this._placeGuidesOnMap[placeGuideId].unhighlight();
+    }
   }
 
   // This function sets the map bound to the minimum one
@@ -97,20 +101,5 @@ class MapPlaceGuideDisplayer {
         placeGuide.creator,
         placeGuide.description,
         placeType);
-  }
-
-  remove(placeGuideId) {
-    this._markerClusterer.removeMarker(
-        this._placeGuidesOnMap[placeGuideId].marker);
-    this._placeGuidesOnMap[placeGuideId].remove();
-    delete this._placeGuidesOnMap[placeGuideId];
-  }
-
-  highlight(placeGuideId) {
-    this._placeGuidesOnMap[placeGuideId].highlight();
-  }
-
-  unhighlight(placeGuideId) {
-    this._placeGuidesOnMap[placeGuideId].unhighlight();
   }
 }

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -418,8 +418,10 @@ class PlaceGuideOnList {
   static close(placeGuideId) {
     const divId = 'placeGuideOnList-' + '{' + placeGuideId + '}';
     const placeGuideDiv = document.getElementById(divId);
-    placeGuideDiv.querySelectorAll('.folded-placeGuide')[0].style.display = 'block';
-    placeGuideDiv.querySelectorAll('.card-placeGuide')[0].style.display = 'none';
-    placeGuideDiv.style.removeProperty('padding');
+    if (placeGuideDiv != null) {
+      placeGuideDiv.querySelectorAll('.folded-placeGuide')[0].style.display = 'block';
+      placeGuideDiv.querySelectorAll('.card-placeGuide')[0].style.display = 'none';
+      placeGuideDiv.style.removeProperty('padding');
+    }
   }
 }

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -419,8 +419,10 @@ class PlaceGuideOnList {
     const divId = 'placeGuideOnList-' + '{' + placeGuideId + '}';
     const placeGuideDiv = document.getElementById(divId);
     if (placeGuideDiv != null) {
-      placeGuideDiv.querySelectorAll('.folded-placeGuide')[0].style.display = 'block';
-      placeGuideDiv.querySelectorAll('.card-placeGuide')[0].style.display = 'none';
+      placeGuideDiv
+          .querySelectorAll('.folded-placeGuide')[0].style.display = 'block';
+      placeGuideDiv
+          .querySelectorAll('.card-placeGuide')[0].style.display = 'none';
       placeGuideDiv.style.removeProperty('padding');
     }
   }

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -418,7 +418,7 @@ class PlaceGuideOnList {
   static close(placeGuideId) {
     const divId = 'placeGuideOnList-' + '{' + placeGuideId + '}';
     const placeGuideDiv = document.getElementById(divId);
-    if (placeGuideDiv != null) {
+    if (placeGuideDiv !== null) {
       placeGuideDiv
           .querySelectorAll('.folded-placeGuide')[0].style.display = 'block';
       placeGuideDiv


### PR DESCRIPTION
#### Context
When a user tries to highlight a placeguide, any previously highlighted guide will be "unhighlighted".

#### Issue
If previously highlighted guide is not on the current map area anymore, the corresponding infobox div and PlaceGuideOnMap object do not exist anymore. Any actions that should be performed on these object will cause a crash. 

#### Solution
To avoid this crash, I simply need to check if the corresponding objects still exist. 