### PR TITLE
Bug Fix: unterminated statement in removePlaceGuide()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
+                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/src/main/java/com/google/sps/servlets/DeletePlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/DeletePlaceGuideServlet.java
@@ -20,9 +20,7 @@ public class DeletePlaceGuideServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String id = request.getParameter("id");
-    String currentUrl = request.getParameter("currentUrl");
     long parsedId = Long.parseLong(id);
     placeGuideRepository.deletePlaceGuide(parsedId);
-    response.sendRedirect(currentUrl);
   }
 }

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -145,7 +145,6 @@ class PlaceGuideRepository {
       // Remove from database.
       const url = new URL("/delete-place-guide-data", document.URL);
       url.searchParams.append('id', placeGuideId);
-      url.searchParams.append('currentUrl', )
       fetch(url)
         .catch(error => {
           console.log("DeletePlaceGuideServlet: failed to fetch: "


### PR DESCRIPTION
#### Issue
A statement responsible for setting a url search parameter for a doGet() request remained unterminated and caused crashes.

#### Solution
Since the parameter was supposed to specify the currentUrl, but redirecting the page to the currentUrl was not actually necessary, I removed the parameter completely, both from the client- and from the server-side.