### PR TITLE
Bug Fix: Editing a guide's location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
-                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
+                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/src/main/webapp/createPlaceGuide.html
+++ b/src/main/webapp/createPlaceGuide.html
@@ -123,10 +123,8 @@
                 </div>
             </div>
 
-            <fieldset style="display: block;">
+            <fieldset style="display: blobk;">
                 <legend>Location of the Guide: </legend>
-                <label for = "placeName">place name : </label><br>
-                <input type = "text" name = "placeName" id = "placeName" readonly class="mdc-text-field mdc-text-field--outlined"><br>
                 <label for = "latitude">latitude : </label><br>
                 <input type = "text" name = "latitude" id = "latitude" onkeypress="return false;" class="mdc-text-field mdc-text-field--outlined"><br>
                 <label for = "longitude">longitude : </label><br>

--- a/src/main/webapp/createPlaceGuide.html
+++ b/src/main/webapp/createPlaceGuide.html
@@ -123,7 +123,7 @@
                 </div>
             </div>
 
-            <fieldset style="display: blobk;">
+            <fieldset style="display: none;">
                 <legend>Location of the Guide: </legend>
                 <label for = "latitude">latitude : </label><br>
                 <input type = "text" name = "latitude" id = "latitude" onkeypress="return false;" class="mdc-text-field mdc-text-field--outlined"><br>

--- a/src/main/webapp/createPlaceGuide.html
+++ b/src/main/webapp/createPlaceGuide.html
@@ -123,7 +123,7 @@
                 </div>
             </div>
 
-            <fieldset style="display: none;">
+            <fieldset style="display: block;">
                 <legend>Location of the Guide: </legend>
                 <label for = "placeName">place name : </label><br>
                 <input type = "text" name = "placeName" id = "placeName" readonly class="mdc-text-field mdc-text-field--outlined"><br>

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -56,21 +56,19 @@ function enableSubmission() {
 function updateLocation(position, placeId, placeName) {
   if (placeName != null) {
     document.getElementById(
-        'placeName').setAttribute('value', placeName);
+        'placeName').value = placeName;
     document.getElementById(
-        'placeId').setAttribute('value', placeId);
+        'placeId').value = placeId;
   } else {
     document.getElementById(
-        'placeName').setAttribute('value', '-');
+        'placeName').value = '-';
     document.getElementById(
-        'placeId').setAttribute('value', '');
+        'placeId').value = '';
   }
   document.getElementById(
-      'latitude').value = position.lat(); //setAttribute('value',
-  // position.lat());
+      'latitude').value = position.lat();
   document.getElementById(
-      'longitude').value = position.lng(); //setAttribute('value',
-  // position.lng());
+      'longitude').value = position.lng();
 }
 
 /**

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -54,7 +54,7 @@ function enableSubmission() {
  * data of the newly chosen location for the placeguide.
  */
 function updateLocation(position, placeId) {
-  if (placeId != null) {
+  if (placeId !== null) {
     document.getElementById(
         'placeId').value = placeId;
   } else {

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -88,7 +88,7 @@ function fillFormWithPlaceGuideToEdit() {
     });
     document.getElementById('id').value = GET['placeGuideId'];
     setFormInputValueOrEmpty(
-        document.getElementById('placeId').value,
+        document.getElementById('placeId'),
         GET['placeId']);
     setFormInputValueOrEmpty(
         new mdc.textField.MDCTextField(document.getElementById('nameInput')),

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -66,9 +66,11 @@ function updateLocation(position, placeId, placeName) {
         'placeId').setAttribute('value', '');
   }
   document.getElementById(
-      'latitude').setAttribute('value', position.lat());
+      'latitude').value = position.lat(); //setAttribute('value',
+  // position.lat());
   document.getElementById(
-      'longitude').setAttribute('value', position.lng());
+      'longitude').value = position.lng(); //setAttribute('value',
+  // position.lng());
 }
 
 /**

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -53,15 +53,11 @@ function enableSubmission() {
  * This function writes in the hidden form inputs the
  * data of the newly chosen location for the placeguide.
  */
-function updateLocation(position, placeId, placeName) {
-  if (placeName != null) {
-    document.getElementById(
-        'placeName').value = placeName;
+function updateLocation(position, placeId) {
+  if (placeId != null) {
     document.getElementById(
         'placeId').value = placeId;
   } else {
-    document.getElementById(
-        'placeName').value = '-';
     document.getElementById(
         'placeId').value = '';
   }

--- a/src/main/webapp/pages/createPlaceGuide_initPage.js
+++ b/src/main/webapp/pages/createPlaceGuide_initPage.js
@@ -46,9 +46,8 @@ function handleChosenLocationChangeEvent(mapWidget) {
   enableSubmission();
   if (mapWidget.pickedLocation.place != null) {
     updateLocation(mapWidget.pickedLocation.position,
-        mapWidget.pickedLocation.place.place_id,
-        mapWidget.pickedLocation.place.name);
+        mapWidget.pickedLocation.place.place_id);
   } else {
-    updateLocation(mapWidget.pickedLocation.position, null, null);
+    updateLocation(mapWidget.pickedLocation.position, null);
   }
 }


### PR DESCRIPTION
#### Issues
1. When the user attempts to edit an existing guide's location, it doesn't seem to change. 
2. If the user edits a guide whose location is specified through a placeId, after the resubmission the placeId will disappear and the guide will be linked to the previous coordinates, but not to the place

#### Solutions
1. As it turns out, the bug was caused by the fact that instead of the value property of the location input fields of the form, only the value attribute was changed. The attribute change was not reflected in the form's submitted values, and thus the location was not updated. To solve this, I had to change the `.setAttribute('value', value)` statements to `.value = value`. See [this](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute) and [this](https://stackoverflow.com/questions/29929797/setattribute-doesnt-work-the-way-i-expect-it-to) links for a more detailed explanation of the issue. 
2. This one was simply caused by a wrong parameter being passed to the setFormInputValueOrEmpty() function. It accepts a DOM element, but got a DOM element's value instead. I removed the .value getter. 

#### Other changes
While testing this part I realized that the placeName input field is not needed anymore, because it is not displayed to the user anymore and it is not required on the server side either. So I removed it completely. 