### PR TITLE
Bug Fix: Geocoding Failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
-                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
                     <!-- TODO: set project ID. -->
                     <deploy.projectId>denniswillie-step-2020</deploy.projectId>
                     <deploy.version>1</deploy.version>
+                    <port>8181</port>
                 </configuration>
             </plugin>
           

--- a/src/main/webapp/placeGuides/ListPlaceGuideDisplayer.js
+++ b/src/main/webapp/placeGuides/ListPlaceGuideDisplayer.js
@@ -98,10 +98,10 @@ class ListPlaceGuideDisplayer {
   }
 
  // Move the highlighted place guide to top of list.
-  highlight(placeGuideId) {
+  highlight(placeGuideId, location) {
     const placeGuideDiv = this.remove(placeGuideId);
     this.insertDivAfterTitle(placeGuideDiv);
-    PlaceGuideOnList.highlight(placeGuideId);
+    PlaceGuideOnList.highlight(placeGuideId, location);
   }
 
   insertDivAfterTitle(placeGuideDiv) {

--- a/src/main/webapp/placeGuides/ListPlaceGuideDisplayer.js
+++ b/src/main/webapp/placeGuides/ListPlaceGuideDisplayer.js
@@ -116,19 +116,9 @@ class ListPlaceGuideDisplayer {
 
   constructPlaceGuideOnListDivFromPlaceGuide(placeGuide) {
     const mapsPlace = placeGuide.location.mapsPlace;
-    var placeName;
-    var placeId;
-    if (mapsPlace == null) {
-      placeName = null;
-      placeId = null;
-    } else {
-      placeName = mapsPlace.name;
-      placeId = mapsPlace.place_id;
-    }
     return new PlaceGuideOnList(
         placeGuide.id,
-        placeName,
-        placeId,
+        placeGuide.location,
         placeGuide.name,
         placeGuide.creator,
         placeGuide.description,

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -26,7 +26,7 @@ class Location {
         });
       }
       const thisLocation = this;
-      this.definePlaceName()
+      return this.definePlaceName()
           .then(newPlaceName => {
             thisLocation._placeName = newPlaceName;
             return newPlaceName;
@@ -36,7 +36,7 @@ class Location {
 
   definePlaceName() {
     const request = {
-      placeId: placeId,
+      placeId: this._placeId,
       fields: ['name'],
     };
     return new Promise(function(resolve, reject) {

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -3,22 +3,29 @@
  * coordinates or by a place_id, which will be decoded with PlacesService.
  */
 class Location {
-  constructor(position, mapsPlace) {
-    this._mapsPlace = mapsPlace;
-    if (this._mapsPlace != null) {
-      this._position = this._mapsPlace.geometry.location;
-    } else {
-      this._position = position;
-    }
+  constructor(position, placeId) {
+    this._position = position;
+    this._placeId = placeId;
+    this._placeName = undefined;
+    // if (this._mapsPlace != null) {
+    //   this._position = this._mapsPlace.geometry.location;
+    // } else {
+    //   this._position = position;
+    // }
   }
 
   get position() {
     return this._position;
   }
 
-  get mapsPlace() {
-    return this._mapsPlace;
-  }
+  // get placeName() {
+  //   if (this._placeName !== undefined) {
+  //     return this._placeName;
+  //   } else {
+  //
+  //   }
+  //   return this._placeName;
+  // }
 
   static constructLocationBasedOnCoordinates(positionLat, positionLng) {
     return new Location(

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -3,8 +3,8 @@
  * coordinates or by a place_id, which will be decoded with PlacesService.
  */
 class Location {
-  constructor(position, placeId) {
-    this._position = position;
+  constructor(latitude, longitude, placeId) {
+    this._position = new google.maps.LatLng(latitude, longitude);
     this._placeId = placeId;
     this._placeName = undefined;
   }

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -31,7 +31,7 @@ class Location {
       }
       const thisLocation = this;
       return this.definePlaceName()
-          .then(newPlaceName => {
+          .then((newPlaceName) => {
             thisLocation._placeName = newPlaceName;
             return newPlaceName;
           });

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -18,18 +18,43 @@ class Location {
     return this._position;
   }
 
-  // get placeName() {
-  //   if (this._placeName !== undefined) {
-  //     return this._placeName;
-  //   } else {
-  //
-  //   }
-  //   return this._placeName;
-  // }
+  get placeName() {
+    if (this._placeName !== undefined) {
+      const thisPlaceName = this._placeName;
+      return new Promise(function(resolve, reject) {
+        return thisPlaceName;
+      });
+    } else {
+      const thisLocation = this;
+      this.definePlaceName()
+          .then(newPlaceName => {
+            thisLocation._placeName = newPlaceName;
+            return newPlaceName;
+          });
+    }
+  }
 
   static constructLocationBasedOnCoordinates(positionLat, positionLng) {
     return new Location(
         new google.maps.LatLng(positionLat, positionLng), null);
+  }
+
+  definePlaceName() {
+    const request = {
+      placeId: placeId,
+      fields: ['name'],
+    };
+    return new Promise(function(resolve, reject) {
+      const service = new google.maps.places.PlacesService(map);
+      service.getDetails(request, (place, status) => {
+        if (status === google.maps.places.PlacesServiceStatus.OK) {
+          resolve(place.name);
+        } else {
+          reject(new Error('Couldn\'t find the place ' + placeId + ' because' +
+              ' ' + status));
+        }
+      });
+    });
   }
 
   static constructLocationBasedOnPlaceId(placeId) {

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -7,11 +7,6 @@ class Location {
     this._position = position;
     this._placeId = placeId;
     this._placeName = undefined;
-    // if (this._mapsPlace != null) {
-    //   this._position = this._mapsPlace.geometry.location;
-    // } else {
-    //   this._position = position;
-    // }
   }
 
   get position() {

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -24,7 +24,7 @@ class Location {
         resolve(thisPlaceName);
       });
     } else {
-      if (this._placeId === undefined) {
+      if (this._placeId == undefined) {
         return new Promise(function(resolve, reject) {
           resolve(undefined);
         });

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -17,9 +17,14 @@ class Location {
     if (this._placeName !== undefined) {
       const thisPlaceName = this._placeName;
       return new Promise(function(resolve, reject) {
-        return thisPlaceName;
+        resolve(thisPlaceName);
       });
     } else {
+      if (this._placeId === undefined) {
+        return new Promise(function(resolve, reject) {
+          resolve(undefined);
+        });
+      }
       const thisLocation = this;
       this.definePlaceName()
           .then(newPlaceName => {

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -34,11 +34,6 @@ class Location {
     }
   }
 
-  static constructLocationBasedOnCoordinates(positionLat, positionLng) {
-    return new Location(
-        new google.maps.LatLng(positionLat, positionLng), null);
-  }
-
   definePlaceName() {
     const request = {
       placeId: placeId,
@@ -52,23 +47,6 @@ class Location {
         } else {
           reject(new Error('Couldn\'t find the place ' + placeId + ' because' +
               ' ' + status));
-        }
-      });
-    });
-  }
-
-  static constructLocationBasedOnPlaceId(placeId) {
-    const request = {
-      placeId: placeId,
-      fields: ['address_components', 'name', 'geometry', 'place_id'],
-    };
-    return new Promise(function(resolve, reject) {
-      const service = new google.maps.places.PlacesService(map);
-      service.getDetails(request, (place, status) => {
-        if (status === google.maps.places.PlacesServiceStatus.OK) {
-          resolve(new Location(null, place));
-        } else {
-          reject(new Error('Couldn\'t find the place ' + placeId));
         }
       });
     });

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -17,7 +17,7 @@ class Location {
     return this._placeId;
   }
 
-  get placeName() {
+  getPlaceName() {
     if (this._placeName !== undefined) {
       const thisPlaceName = this._placeName;
       return new Promise(function(resolve, reject) {

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -13,6 +13,10 @@ class Location {
     return this._position;
   }
 
+  get placeId() {
+    return this._placeId;
+  }
+
   get placeName() {
     if (this._placeName !== undefined) {
       const thisPlaceName = this._placeName;

--- a/src/main/webapp/placeGuides/MapPlaceGuideDisplayer.js
+++ b/src/main/webapp/placeGuides/MapPlaceGuideDisplayer.js
@@ -96,8 +96,7 @@ class MapPlaceGuideDisplayer {
     }
     return new PlaceGuideOnMap(placeGuide.id,
         placeGuide.name,
-        placeGuide.location.position,
-        placeGuide.location.mapsPlace,
+        placeGuide.location,
         placeGuide.creator,
         placeGuide.description,
         placeType);

--- a/src/main/webapp/placeGuides/PlaceGuideManager.js
+++ b/src/main/webapp/placeGuides/PlaceGuideManager.js
@@ -48,8 +48,7 @@ class PlaceGuideManager {
 
   refreshPlaceGuides(bounds, zoom) {
     this._placeGuideRepository.fetchPlaceGuides(this._page.query, bounds, zoom)
-        .then((response) => {
-          const placeGuides = this._placeGuideRepository.placeGuides;
+        .then((placeGuides) => {
           this._listPlaceGuideDisplayer.update(placeGuides);
           this._mapPlaceGuideDisplayer.update(placeGuides);
           if (this._page === PlaceGuideManager.PAGE.BOOKMARKED_PLACEGUIDES) {

--- a/src/main/webapp/placeGuides/PlaceGuideManager.js
+++ b/src/main/webapp/placeGuides/PlaceGuideManager.js
@@ -77,7 +77,8 @@ class PlaceGuideManager {
     }
     this._highlightedPlaceGuideId = placeGuideId;
     this._mapPlaceGuideDisplayer.highlight(placeGuideId);
-    this._listPlaceGuideDisplayer.highlight(placeGuideId);
+    this._listPlaceGuideDisplayer.highlight(placeGuideId,
+        this._placeGuideRepository.location(placeGuideId));
   }
 
   unhighlightPlaceGuide() {

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -107,12 +107,22 @@ class PlaceGuideOnList {
     return buttonsContainer;
   }
 
-  static expand(placeGuideId) {
+  static expand(placeGuideId, location) {
     const divId = 'placeGuideOnList-' + '{' + placeGuideId + '}';
     const placeGuideDiv = document.getElementById(divId);
-    placeGuideDiv.querySelectorAll('.folded-placeGuide')[0].style.display = 'none';
-    placeGuideDiv.querySelectorAll('.card-placeGuide')[0].style.display = 'block';
-    placeGuideDiv.style.padding = '0px';
+    location.placeName
+        .then(placeName => {
+          if (placeName !== undefined) {
+            document.getElementById(
+                PlaceGuideOnList.getPlaceGuidePlaceNameElementId(placeGuideId))
+                .innerText = placeName;
+          }
+          placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
+              .style.display = 'none';
+          placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
+              .style.display = 'block';
+          placeGuideDiv.style.padding = '0px';
+        });
   }
 
   createCardPlaceGuide(
@@ -225,9 +235,15 @@ class PlaceGuideOnList {
 
   createPlaceGuidePlaceNameElement() {
     const placeNameElement = document.createElement('h5');
+    const divId = PlaceGuideOnList.getPlaceGuidePlaceNameElementId();
+    placeNameElement.setAttribute('id', divId);
     placeNameElement.classList.add('place-guide-place-name');
     placeNameElement.innerText = "Random Name";
     return placeNameElement;
+  }
+
+  static getPlaceGuidePlaceNameElementId(placeGuideId) {
+    return `placeGuidePlaceName-{${placeGuideId}}`;
   }
 
   createPlaceGuideDescriptionElement(placeGuideDescription) {

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -1,12 +1,11 @@
 class PlaceGuideOnList {
   constructor(
-      placeGuideId, placeName, placeId, name, creator, description,
+      placeGuideId, location, name, creator, description,
       audioKey, audioLength, isPublic, imageKey, createdByCurrentUser,
       bookmarkedByCurrentUser, latitude, longitude) {
     this._placeGuideProperties = {
       placeGuideId: placeGuideId,
-      placeName: placeName,
-      placeId: placeId,
+      location: location,
       name: name,
       audioKey: audioKey,
       imageKey: imageKey,

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -116,22 +116,22 @@ class PlaceGuideOnList {
     if (placeNameDiv !== null && placeNameDiv.innerText === "") {
       location.placeName
           .then(placeName => {
-            placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
-                .style.display = 'none';
-            placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
-                .style.display = 'block';
-            placeGuideDiv.style.padding = '0px';
+            PlaceGuideOnList.showCardInsteadOfFoldedGuide(placeGuideDiv);
             if (placeName !== undefined) {
               placeNameDiv.innerText = placeName;
             }
           });
     } else {
-      placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
-          .style.display = 'none';
-      placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
-          .style.display = 'block';
-      placeGuideDiv.style.padding = '0px';
+      PlaceGuideOnList.showCardInsteadOfFoldedGuide(placeGuideDiv);
     }
+  }
+
+  static showCardInsteadOfFoldedGuide(placeGuideDiv) {
+    placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
+        .style.display = 'none';
+    placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
+        .style.display = 'block';
+    placeGuideDiv.style.padding = '0px';
   }
 
   createCardPlaceGuide(

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -1,11 +1,12 @@
 class PlaceGuideOnList {
   constructor(
-      placeGuideId, location, name, creator, description,
+      placeGuideId, placeName, placeId, name, creator, description,
       audioKey, audioLength, isPublic, imageKey, createdByCurrentUser,
       bookmarkedByCurrentUser, latitude, longitude) {
     this._placeGuideProperties = {
       placeGuideId: placeGuideId,
-      location: location,
+      placeName: placeName,
+      placeId: placeId,
       name: name,
       audioKey: audioKey,
       imageKey: imageKey,
@@ -71,7 +72,6 @@ class PlaceGuideOnList {
     const placeGuideAudioKey = placeGuideProperties.audioKey;
     const placeGuideId = placeGuideProperties.placeGuideId;
     const placeGuideName = placeGuideProperties.name;
-    // todo
     const placeName = placeGuideProperties.placeName;
     const foldedPlaceGuideDiv = document.createElement('div');
     foldedPlaceGuideDiv.style.display = 'block';
@@ -107,7 +107,6 @@ class PlaceGuideOnList {
     return placeGuideNameContainer;
   }
 
-  // todo
   foldedPlaceGuide_placeName(placeName) {
     const placeNameElement = document.createElement('p');
     placeNameElement.classList.add('mb-1');
@@ -186,10 +185,6 @@ class PlaceGuideOnList {
         this.createPlaceGuideLengthElement(placeGuideProperties.audioLength);
     const placeGuideDescription =
         this.createPlaceGuideDescriptionElement(placeGuideProperties.description);
-    // todo: add placename to card content
-    // if (placeName != undefined || placeName != '' || placeName != null) {
-    //   foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_placeName(placeName));
-    // }
 
     cardContents.appendChild(placeGuideImage);
     cardContents.appendChild(placeGuideTitle);

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -241,7 +241,7 @@ class PlaceGuideOnList {
 
     cardContents.appendChild(placeGuideImage);
     cardContents.appendChild(placeGuideTitle);
-    if (this._placeGuideProperties.location.placeId !== undefined) {
+    if (this._placeGuideProperties.location.placeId != undefined) {
       const placeGuidePlaceName =
           this.createPlaceGuidePlaceNameElement();
       cardContents.appendChild(placeGuidePlaceName);

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -77,9 +77,9 @@ class PlaceGuideOnList {
     foldedPlaceGuideDiv.style.display = 'block';
     foldedPlaceGuideDiv.classList.add('folded-placeGuide');
     foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_name(placeGuideName));
-    if (placeName != undefined || placeName != '' || placeName != null) {
-      foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_placeName(placeName));
-    }
+    // if (placeName != undefined || placeName != '' || placeName != null) {
+    //   foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_placeName(placeName));
+    // }
     foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_buttons(placeGuideId, placeGuideAudioKey));
     return foldedPlaceGuideDiv;
   }

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -77,9 +77,6 @@ class PlaceGuideOnList {
     foldedPlaceGuideDiv.style.display = 'block';
     foldedPlaceGuideDiv.classList.add('folded-placeGuide');
     foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_name(placeGuideName));
-    // if (placeName != undefined || placeName != '' || placeName != null) {
-    //   foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_placeName(placeName));
-    // }
     foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_buttons(placeGuideId, placeGuideAudioKey));
     return foldedPlaceGuideDiv;
   }

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -1,12 +1,11 @@
 class PlaceGuideOnList {
   constructor(
-      placeGuideId, placeName, placeId, name, creator, description,
+      placeGuideId, location, name, creator, description,
       audioKey, audioLength, isPublic, imageKey, createdByCurrentUser,
       bookmarkedByCurrentUser, latitude, longitude) {
     this._placeGuideProperties = {
       placeGuideId: placeGuideId,
-      placeName: placeName,
-      placeId: placeId,
+      location: location,
       name: name,
       audioKey: audioKey,
       imageKey: imageKey,
@@ -72,6 +71,7 @@ class PlaceGuideOnList {
     const placeGuideAudioKey = placeGuideProperties.audioKey;
     const placeGuideId = placeGuideProperties.placeGuideId;
     const placeGuideName = placeGuideProperties.name;
+    // todo
     const placeName = placeGuideProperties.placeName;
     const foldedPlaceGuideDiv = document.createElement('div');
     foldedPlaceGuideDiv.style.display = 'block';
@@ -107,6 +107,7 @@ class PlaceGuideOnList {
     return placeGuideNameContainer;
   }
 
+  // todo
   foldedPlaceGuide_placeName(placeName) {
     const placeNameElement = document.createElement('p');
     placeNameElement.classList.add('mb-1');
@@ -185,6 +186,10 @@ class PlaceGuideOnList {
         this.createPlaceGuideLengthElement(placeGuideProperties.audioLength);
     const placeGuideDescription =
         this.createPlaceGuideDescriptionElement(placeGuideProperties.description);
+    // todo: add placename to card content
+    // if (placeName != undefined || placeName != '' || placeName != null) {
+    //   foldedPlaceGuideDiv.appendChild(this.foldedPlaceGuide_placeName(placeName));
+    // }
 
     cardContents.appendChild(placeGuideImage);
     cardContents.appendChild(placeGuideTitle);

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -111,19 +111,27 @@ class PlaceGuideOnList {
   static expand(placeGuideId, location) {
     const divId = 'placeGuideOnList-' + '{' + placeGuideId + '}';
     const placeGuideDiv = document.getElementById(divId);
-    location.placeName
-        .then(placeName => {
-          placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
-              .style.display = 'none';
-          placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
-              .style.display = 'block';
-          placeGuideDiv.style.padding = '0px';
-          if (placeName !== undefined) {
-            document.getElementById(
-                PlaceGuideOnList.getPlaceGuidePlaceNameElementId(placeGuideId))
-                .innerText = placeName;
-          }
-        });
+    const placeNameDiv =  document.getElementById(
+        PlaceGuideOnList.getPlaceGuidePlaceNameElementId(placeGuideId));
+    if (placeNameDiv !== null && placeNameDiv.innerText === "") {
+      location.placeName
+          .then(placeName => {
+            placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
+                .style.display = 'none';
+            placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
+                .style.display = 'block';
+            placeGuideDiv.style.padding = '0px';
+            if (placeName !== undefined) {
+              placeNameDiv.innerText = placeName;
+            }
+          });
+    } else {
+      placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
+          .style.display = 'none';
+      placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
+          .style.display = 'block';
+      placeGuideDiv.style.padding = '0px';
+    }
   }
 
   createCardPlaceGuide(
@@ -242,7 +250,7 @@ class PlaceGuideOnList {
         this._placeGuideProperties.placeGuideId);
     placeNameElement.setAttribute('id', divId);
     placeNameElement.classList.add('place-guide-place-name');
-    placeNameElement.innerText = "Random Name";
+    placeNameElement.innerText = "";
     return placeNameElement;
   }
 

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -93,26 +93,6 @@ class PlaceGuideOnList {
     return placeGuideNameContainer;
   }
 
-  foldedPlaceGuide_name(placeGuideName) {
-    const placeGuideNameContainer = document.createElement('div');
-    placeGuideNameContainer.classList.add(
-        'd-flex',
-        'w-100',
-        'justify-content-between');
-    const placeGuideNameElement = document.createElement('h5');
-    placeGuideNameElement.classList.add('mb-1');
-    placeGuideNameElement.innerText = placeGuideName;
-    placeGuideNameContainer.appendChild(placeGuideNameElement);
-    return placeGuideNameContainer;
-  }
-
-  foldedPlaceGuide_placeName(placeName) {
-    const placeNameElement = document.createElement('p');
-    placeNameElement.classList.add('mb-1');
-    placeNameElement.innerText = placeName;
-    return placeNameElement;
-  }
-
   foldedPlaceGuide_buttons(placeGuideId, audioKey) {
     const buttonsContainer = document.createElement('div');
     buttonsContainer.classList.add('mdc-card__action-icons');
@@ -182,11 +162,14 @@ class PlaceGuideOnList {
         this.createPlaceGuideTitle(placeGuideProperties.name, creator.email);
     const placeGuideLength =
         this.createPlaceGuideLengthElement(placeGuideProperties.audioLength);
+    const placeGuidePlaceName =
+        this.createPlaceGuidePlaceNameElement();
     const placeGuideDescription =
         this.createPlaceGuideDescriptionElement(placeGuideProperties.description);
 
     cardContents.appendChild(placeGuideImage);
     cardContents.appendChild(placeGuideTitle);
+    cardContents.appendChild(placeGuidePlaceName);
     cardContents.appendChild(placeGuideLength);
     cardContents.appendChild(placeGuideDescription);
     cardContentsContainer.appendChild(cardContents);
@@ -238,6 +221,13 @@ class PlaceGuideOnList {
     placeGuideLength.classList.add('place-guide-length');
     placeGuideLength.innerText = placeGuideAudioLength + ' minutes';
     return placeGuideLength;
+  }
+
+  createPlaceGuidePlaceNameElement() {
+    const placeNameElement = document.createElement('h5');
+    placeNameElement.classList.add('place-guide-place-name');
+    placeNameElement.innerText = "Random Name";
+    return placeNameElement;
   }
 
   createPlaceGuideDescriptionElement(placeGuideDescription) {

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -27,8 +27,8 @@ class PlaceGuideOnList {
     return this._placeGuideOnListDiv;
   }
 
-  static highlight(placeGuideId) {
-    PlaceGuideOnList.expand(placeGuideId);
+  static highlight(placeGuideId, location) {
+    PlaceGuideOnList.expand(placeGuideId, location);
   }
 
   static unhighlight(placeGuideId) {
@@ -100,8 +100,9 @@ class PlaceGuideOnList {
     const expandButton = this.getPlaceGuideButtonWithPreparedClasses();
     expandButton.setAttribute('title', 'expand');
     expandButton.innerText = 'open_in_full';
+    const placeGuideLocation = this._placeGuideProperties.location;
     expandButton.addEventListener('click', function() {
-      PlaceGuideOnList.expand(placeGuideId);
+      PlaceGuideOnList.expand(placeGuideId, placeGuideLocation);
     });
     buttonsContainer.appendChild(expandButton);
     return buttonsContainer;
@@ -112,16 +113,16 @@ class PlaceGuideOnList {
     const placeGuideDiv = document.getElementById(divId);
     location.placeName
         .then(placeName => {
-          if (placeName !== undefined) {
-            document.getElementById(
-                PlaceGuideOnList.getPlaceGuidePlaceNameElementId(placeGuideId))
-                .innerText = placeName;
-          }
           placeGuideDiv.querySelectorAll('.folded-placeGuide')[0]
               .style.display = 'none';
           placeGuideDiv.querySelectorAll('.card-placeGuide')[0]
               .style.display = 'block';
           placeGuideDiv.style.padding = '0px';
+          if (placeName !== undefined) {
+            document.getElementById(
+                PlaceGuideOnList.getPlaceGuidePlaceNameElementId(placeGuideId))
+                .innerText = placeName;
+          }
         });
   }
 
@@ -172,14 +173,16 @@ class PlaceGuideOnList {
         this.createPlaceGuideTitle(placeGuideProperties.name, creator.email);
     const placeGuideLength =
         this.createPlaceGuideLengthElement(placeGuideProperties.audioLength);
-    const placeGuidePlaceName =
-        this.createPlaceGuidePlaceNameElement();
     const placeGuideDescription =
         this.createPlaceGuideDescriptionElement(placeGuideProperties.description);
 
     cardContents.appendChild(placeGuideImage);
     cardContents.appendChild(placeGuideTitle);
-    cardContents.appendChild(placeGuidePlaceName);
+    if (this._placeGuideProperties.location.placeId !== undefined) {
+      const placeGuidePlaceName =
+          this.createPlaceGuidePlaceNameElement();
+      cardContents.appendChild(placeGuidePlaceName);
+    }
     cardContents.appendChild(placeGuideLength);
     cardContents.appendChild(placeGuideDescription);
     cardContentsContainer.appendChild(cardContents);
@@ -235,7 +238,8 @@ class PlaceGuideOnList {
 
   createPlaceGuidePlaceNameElement() {
     const placeNameElement = document.createElement('h5');
-    const divId = PlaceGuideOnList.getPlaceGuidePlaceNameElementId();
+    const divId = PlaceGuideOnList.getPlaceGuidePlaceNameElementId(
+        this._placeGuideProperties.placeGuideId);
     placeNameElement.setAttribute('id', divId);
     placeNameElement.classList.add('place-guide-place-name');
     placeNameElement.innerText = "Random Name";

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -124,7 +124,6 @@ class PlaceGuideOnList {
     const placeGuideAudioKey = placeGuideProperties.audioKey;
     const placeGuideId = placeGuideProperties.placeGuideId;
     const placeGuideName = placeGuideProperties.name;
-    const placeName = placeGuideProperties.placeName;
     const foldedPlaceGuideDiv = document.createElement('div');
     foldedPlaceGuideDiv.style.display = 'block';
     foldedPlaceGuideDiv.classList.add('folded-placeGuide');
@@ -167,7 +166,7 @@ class PlaceGuideOnList {
     const placeNameDiv = document.getElementById(
         PlaceGuideOnList.getPlaceGuidePlaceNameElementId(placeGuideId));
     if (placeNameDiv !== null && placeNameDiv.innerText === "") {
-      location.placeName
+      location.getPlaceName()
           .then((placeName) => {
             PlaceGuideOnList.showCardInsteadOfFoldedGuide(placeGuideDiv);
             if (placeName !== undefined) {

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -140,11 +140,11 @@ class PlaceGuideOnList {
   static expand(placeGuideId, location) {
     const divId = 'placeGuideOnList-' + '{' + placeGuideId + '}';
     const placeGuideDiv = document.getElementById(divId);
-    const placeNameDiv =  document.getElementById(
+    const placeNameDiv = document.getElementById(
         PlaceGuideOnList.getPlaceGuidePlaceNameElementId(placeGuideId));
     if (placeNameDiv !== null && placeNameDiv.innerText === "") {
       location.placeName
-          .then(placeName => {
+          .then((placeName) => {
             PlaceGuideOnList.showCardInsteadOfFoldedGuide(placeGuideDiv);
             if (placeName !== undefined) {
               placeNameDiv.innerText = placeName;

--- a/src/main/webapp/placeGuides/PlaceGuideOnMap.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnMap.js
@@ -4,10 +4,13 @@
  */
 class PlaceGuideOnMap {
   constructor(id, name, location, creator, description, placeType) {
+    this._guideName = name;
+    this._creator = creator;
+    this._description = description;
     this._id = id;
-    this._infoWindowClosed = true;
     this._location = location;
     this._marker = PlaceGuideOnMap.getMarker(placeType, name, location.position);
+    this._infoWindow = undefined;
     this._highlighted = false;
     this.setupHighlightOnMarkerClick();
     this.setupUnhighlightOnMapClick();
@@ -42,10 +45,10 @@ class PlaceGuideOnMap {
     return markerIcon;
   }
 
-  static getInfoWindow(name, position, place, creator, description) {
+  static getInfoWindow(name, position, placeName, creator, description) {
     return new google.maps.InfoWindow({
       content: PlaceGuideOnMap
-          .getInfoWindowContent(name, position, place, creator, description),
+          .getInfoWindowContent(name, position, placeName, creator, description),
       maxWidth: 200,
     });
   }
@@ -86,16 +89,22 @@ class PlaceGuideOnMap {
 
   closeInfoWindow() {
     this._infoWindow.close();
-    this._infoWindowClosed = true;
   }
 
   openInfoWindow() {
     if (this._infoWindow != undefined) {
       this._infoWindow.open(map, this._marker);
-      this._infoWindowClosed = false;
     } else {
-      this._infoWindow = PlaceGuideOnMap
-          .getInfoWindow(name, position, place, creator, description);
+      this._location.placeName
+          .then(placeName => function() {
+            this._infoWindow = PlaceGuideOnMap
+                .getInfoWindow(this._guideName,
+                               this._location.position,
+                               placeName,
+                               this._creator,
+                               this._description);
+            this._infoWindow.open(map, this._marker);
+          });
     }
   }
 

--- a/src/main/webapp/placeGuides/PlaceGuideOnMap.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnMap.js
@@ -96,7 +96,7 @@ class PlaceGuideOnMap {
       this._infoWindow.open(map, this._marker);
     } else {
       this._location.placeName
-          .then(placeName => function() {
+          .then(placeName => {
             this._infoWindow = PlaceGuideOnMap
                 .getInfoWindow(this._guideName,
                                this._location.position,

--- a/src/main/webapp/placeGuides/PlaceGuideOnMap.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnMap.js
@@ -12,6 +12,7 @@ class PlaceGuideOnMap {
     this._marker = PlaceGuideOnMap.getMarker(placeType, name, location.position);
     this._infoWindow = undefined;
     this._highlighted = false;
+    this._highlightingStopped = false;
     this.setupHighlightOnMarkerClick();
     this.setupUnhighlightOnMapClick();
   }
@@ -78,6 +79,7 @@ class PlaceGuideOnMap {
   }
 
   highlight() {
+    this._highlightingStopped = false;
     if (this._infoWindow !== undefined) {
       this._infoWindow.open(map, this._marker);
       this._highlighted = true;
@@ -90,14 +92,17 @@ class PlaceGuideOnMap {
                     placeName,
                     this._creator,
                     this._description);
-            this._infoWindow.open(map, this._marker);
-            this._highlighted = true;
+            if (!this._highlightingStopped) {
+              this._infoWindow.open(map, this._marker);
+              this._highlighted = true;
+            }
           });
     }
   }
 
   unhighlight() {
     if (this._infoWindow !== undefined) {
+      this._highlightingStopped = true;
       this._infoWindow.close();
     }
     this._highlighted = false;

--- a/src/main/webapp/placeGuides/PlaceGuideOnMap.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnMap.js
@@ -3,12 +3,11 @@
  * placeGuide on map.
  */
 class PlaceGuideOnMap {
-  constructor(id, name, position, place, creator, description, placeType) {
+  constructor(id, name, location, creator, description, placeType) {
     this._id = id;
     this._infoWindowClosed = true;
-    this._infoWindow = PlaceGuideOnMap
-        .getInfoWindow(name, position, place, creator, description);
-    this._marker = PlaceGuideOnMap.getMarker(placeType, name, position);
+    this._location = location;
+    this._marker = PlaceGuideOnMap.getMarker(placeType, name, location.position);
     this._highlighted = false;
     this.setupHighlightOnMarkerClick();
     this.setupUnhighlightOnMapClick();
@@ -51,12 +50,12 @@ class PlaceGuideOnMap {
     });
   }
 
-  static getInfoWindowContent(name, position, place, creator, description) {
-    let placeName;
-    if (place != null) {
-      placeName = place.name;
+  static getInfoWindowContent(name, position, placeName, creator, description) {
+    let toDisplayPlaceName;
+    if (placeName !== undefined) {
+      toDisplayPlaceName = placeName;
     } else {
-      placeName = position.toString();
+      toDisplayPlaceName = position.toString();
     }
     let creatorName = creator.name;
     if (creatorName == undefined) {
@@ -64,7 +63,7 @@ class PlaceGuideOnMap {
     }
     let content = `<h3>${name}</h3>
       <h4> Created by: ${creatorName}</h4>
-      <h4> Place: ${placeName}</h4>`;
+      <h4> Place: ${toDisplayPlaceName}</h4>`;
     if (description != undefined) {
       content += `<p>${description}</p>`;
     }
@@ -91,8 +90,13 @@ class PlaceGuideOnMap {
   }
 
   openInfoWindow() {
-    this._infoWindow.open(map, this._marker);
-    this._infoWindowClosed = false;
+    if (this._infoWindow != undefined) {
+      this._infoWindow.open(map, this._marker);
+      this._infoWindowClosed = false;
+    } else {
+      this._infoWindow = PlaceGuideOnMap
+          .getInfoWindow(name, position, place, creator, description);
+    }
   }
 
   remove() {

--- a/src/main/webapp/placeGuides/PlaceGuideOnMap.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnMap.js
@@ -9,7 +9,8 @@ class PlaceGuideOnMap {
     this._description = description;
     this._id = id;
     this._location = location;
-    this._marker = PlaceGuideOnMap.getMarker(placeType, name, location.position);
+    this._marker = PlaceGuideOnMap
+        .getMarker(placeType, name, location.position);
     this._infoWindow = undefined;
     this._highlighted = false;
     this._highlightingStopped = false;
@@ -49,7 +50,8 @@ class PlaceGuideOnMap {
   static getInfoWindow(name, position, placeName, creator, description) {
     return new google.maps.InfoWindow({
       content: PlaceGuideOnMap
-          .getInfoWindowContent(name, position, placeName, creator, description),
+          .getInfoWindowContent(
+              name, position, placeName, creator, description),
       maxWidth: 200,
     });
   }
@@ -85,7 +87,7 @@ class PlaceGuideOnMap {
       this._highlighted = true;
     } else {
       this._location.placeName
-          .then(placeName => {
+          .then((placeName) => {
             this._infoWindow = PlaceGuideOnMap
                 .getInfoWindow(this._guideName,
                     this._location.position,
@@ -117,7 +119,7 @@ class PlaceGuideOnMap {
       this._infoWindow.open(map, this._marker);
     } else {
       this._location.placeName
-          .then(placeName => {
+          .then((placeName) => {
             this._infoWindow = PlaceGuideOnMap
                 .getInfoWindow(this._guideName,
                                this._location.position,

--- a/src/main/webapp/placeGuides/PlaceGuideOnMap.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnMap.js
@@ -86,7 +86,7 @@ class PlaceGuideOnMap {
       this._infoWindow.open(map, this._marker);
       this._highlighted = true;
     } else {
-      this._location.placeName
+      this._location.getPlaceName()
           .then((placeName) => {
             this._infoWindow = PlaceGuideOnMap
                 .getInfoWindow(this._guideName,
@@ -118,7 +118,7 @@ class PlaceGuideOnMap {
     if (this._infoWindow !== undefined) {
       this._infoWindow.open(map, this._marker);
     } else {
-      this._location.placeName
+      this._location.getPlaceName
           .then((placeName) => {
             this._infoWindow = PlaceGuideOnMap
                 .getInfoWindow(this._guideName,

--- a/src/main/webapp/placeGuides/PlaceGuideOnMap.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnMap.js
@@ -78,13 +78,29 @@ class PlaceGuideOnMap {
   }
 
   highlight() {
-    this._highlighted = true;
-    this.openInfoWindow();
+    if (this._infoWindow !== undefined) {
+      this._infoWindow.open(map, this._marker);
+      this._highlighted = true;
+    } else {
+      this._location.placeName
+          .then(placeName => {
+            this._infoWindow = PlaceGuideOnMap
+                .getInfoWindow(this._guideName,
+                    this._location.position,
+                    placeName,
+                    this._creator,
+                    this._description);
+            this._infoWindow.open(map, this._marker);
+            this._highlighted = true;
+          });
+    }
   }
 
   unhighlight() {
+    if (this._infoWindow !== undefined) {
+      this._infoWindow.close();
+    }
     this._highlighted = false;
-    this.closeInfoWindow();
   }
 
   closeInfoWindow() {
@@ -92,7 +108,7 @@ class PlaceGuideOnMap {
   }
 
   openInfoWindow() {
-    if (this._infoWindow != undefined) {
+    if (this._infoWindow !== undefined) {
       this._infoWindow.open(map, this._marker);
     } else {
       this._location.placeName

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -44,46 +44,23 @@ class PlaceGuideRepository {
   }
 
   static getPlaceGuideFromPlaceGuideWithCreatorPair(placeGuideInfo) {
-    var thisRepository = this;
-    return new Promise(function (resolve, reject) {
-      var creator = thisRepository.getUserFromResponse(placeGuideInfo.creator);
-      var placeGuideResponse = placeGuideInfo.placeGuide;
-      if (placeGuideResponse.placeId !== undefined) {
-        Location.constructLocationBasedOnPlaceId(placeGuideResponse.placeId)
-            .then(location => {
-              var placeGuide = new PlaceGuide(placeGuideResponse.id,
-                  placeGuideResponse.name,
-                  location,
-                  placeGuideResponse.audioKey,
-                  placeGuideResponse.length,
-                  placeGuideResponse.imageKey,
-                  creator,
-                  placeGuideResponse.description,
-                  placeGuideResponse.isPublic,
-                  placeGuideInfo.createdByCurrentUser,
-                  placeGuideInfo.bookmarkedByCurrentUser);
-              resolve(placeGuide);
-            });
-      } else {
-        var location =
-            Location.constructLocationBasedOnCoordinates(
-                placeGuideResponse.coordinate.latitude,
-                placeGuideResponse.coordinate.longitude);
-        var placeGuide = new PlaceGuide(placeGuideResponse.id,
-            placeGuideResponse.name,
-            location,
-            placeGuideResponse.audioKey,
-            placeGuideResponse.length,
-            placeGuideResponse.imageKey,
-            creator,
-            placeGuideResponse.description,
-            placeGuideResponse.isPublic,
-            placeGuideInfo.createdByCurrentUser,
-            placeGuideInfo.bookmarkedByCurrentUser);
-        resolve(placeGuide);
-      }
-    });
-
+    const creator = thisRepository.getUserFromResponse(placeGuideInfo.creator);
+    const placeGuideResponse = placeGuideInfo.placeGuide;
+    const location = new Location(placeGuideResponse.coordinate.latitude,
+                                  placeGuideResponse.coordinate.longitude,
+                                  placeGuideResponse.placeId);
+    const placeGuide = new PlaceGuide(placeGuideResponse.id,
+                                      placeGuideResponse.name,
+                                      location,
+                                      placeGuideResponse.audioKey,
+                                      placeGuideResponse.length,
+                                      placeGuideResponse.imageKey,
+                                      creator,
+                                      placeGuideResponse.description,
+                                      placeGuideResponse.isPublic,
+                                      placeGuideInfo.createdByCurrentUser,
+                                      placeGuideInfo.bookmarkedByCurrentUser);
+    return placeGuide;
   }
 
   static getUserFromResponse(userResponse) {

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -17,9 +17,14 @@ class PlaceGuideRepository {
     this._placeGuides = {};
   }
 
-  get placeGuides() {
-    return this._placeGuides;
-  }
+  // get placeGuides() {
+  //   for (const placeGuideId in this._placeGuides) {
+  //     if (this._placeGuides.hasOwnProperty(placeGuideId)) {
+  //       console.log(this._placeGuides[placeGuideId]);
+  //     }
+  //   }
+  //   return this._placeGuides;
+  // }
 
   static buildPlaceGuideDictionaryFromResponse(placeGuideWithCreatorPairs) {
     var placeGuidesDict = {};
@@ -29,10 +34,11 @@ class PlaceGuideRepository {
             placeGuideWithCreatorPairs[i]);
       placeGuidesDict[placeGuide.id] = placeGuide;
     }
+    return placeGuidesDict;
   }
 
   static getPlaceGuideFromPlaceGuideWithCreatorPair(placeGuideInfo) {
-    const creator = thisRepository.getUserFromResponse(placeGuideInfo.creator);
+    const creator = PlaceGuideRepository.getUserFromResponse(placeGuideInfo.creator);
     const placeGuideResponse = placeGuideInfo.placeGuide;
     const location = new Location(placeGuideResponse.coordinate.latitude,
                                   placeGuideResponse.coordinate.longitude,
@@ -83,16 +89,17 @@ class PlaceGuideRepository {
                   + error);
             alert("Failed to process the data of guides");
           })
-          .then(placeGuideWithCreatorPairs => function() {
+          .then(placeGuideWithCreatorPairs => {
             thisRepository._placeGuides = PlaceGuideRepository
                 .buildPlaceGuideDictionaryFromResponse(
-                    placeGuideWithCreatorPairs)
+                    placeGuideWithCreatorPairs);
+            return thisRepository._placeGuides;
           });
     } else {
       var thisRepository = this;
       return new Promise(function (resolve, reject) {
         thisRepository._placeGuides = {};
-        resolve();
+        resolve(thisRepository._placeGuides);
       });
     }
   }

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -156,4 +156,8 @@ class PlaceGuideRepository {
   isBookmarked(placeGuideId) {
     return this._placeGuides[placeGuideId].bookmarkedByCurrentUser;
   }
+
+  location(placeGuideId) {
+    return this._placeGuides[placeGuideId].location;
+  }
 }

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -24,15 +24,6 @@ class PlaceGuideRepository {
     this._placeGuides = {};
   }
 
-  // get placeGuides() {
-  //   for (const placeGuideId in this._placeGuides) {
-  //     if (this._placeGuides.hasOwnProperty(placeGuideId)) {
-  //       console.log(this._placeGuides[placeGuideId]);
-  //     }
-  //   }
-  //   return this._placeGuides;
-  // }
-
   static buildPlaceGuideDictionaryFromResponse(placeGuideWithCreatorPairs) {
     var placeGuidesDict = {};
     for (var i = 0; i < placeGuideWithCreatorPairs.length; i++) {

--- a/src/main/webapp/placeGuides/PlaceGuideRepository.js
+++ b/src/main/webapp/placeGuides/PlaceGuideRepository.js
@@ -23,24 +23,12 @@ class PlaceGuideRepository {
 
   static buildPlaceGuideDictionaryFromResponse(placeGuideWithCreatorPairs) {
     var placeGuidesDict = {};
-    var promises = [];
-    return new Promise(function (resolve, reject) {
-          for (var i = 0; i < placeGuideWithCreatorPairs.length; i++) {
-            promises.push(new Promise(function (resolve, reject) {
-              PlaceGuideRepository
-                  .getPlaceGuideFromPlaceGuideWithCreatorPair(
-                      placeGuideWithCreatorPairs[i])
-                  .then(placeGuide => {
-                    placeGuidesDict[placeGuide.id] = placeGuide;
-                  })
-                  .then(finished => resolve())
-            }));
-          }
-          Promise.all(promises).then(() => {
-            resolve(placeGuidesDict);
-          });
-        }
-    );
+    for (var i = 0; i < placeGuideWithCreatorPairs.length; i++) {
+      const placeGuide = PlaceGuideRepository
+          .getPlaceGuideFromPlaceGuideWithCreatorPair(
+            placeGuideWithCreatorPairs[i]);
+      placeGuidesDict[placeGuide.id] = placeGuide;
+    }
   }
 
   static getPlaceGuideFromPlaceGuideWithCreatorPair(placeGuideInfo) {
@@ -49,18 +37,17 @@ class PlaceGuideRepository {
     const location = new Location(placeGuideResponse.coordinate.latitude,
                                   placeGuideResponse.coordinate.longitude,
                                   placeGuideResponse.placeId);
-    const placeGuide = new PlaceGuide(placeGuideResponse.id,
-                                      placeGuideResponse.name,
-                                      location,
-                                      placeGuideResponse.audioKey,
-                                      placeGuideResponse.length,
-                                      placeGuideResponse.imageKey,
-                                      creator,
-                                      placeGuideResponse.description,
-                                      placeGuideResponse.isPublic,
-                                      placeGuideInfo.createdByCurrentUser,
-                                      placeGuideInfo.bookmarkedByCurrentUser);
-    return placeGuide;
+    return new PlaceGuide(placeGuideResponse.id,
+                          placeGuideResponse.name,
+                          location,
+                          placeGuideResponse.audioKey,
+                          placeGuideResponse.length,
+                          placeGuideResponse.imageKey,
+                          creator,
+                          placeGuideResponse.description,
+                          placeGuideResponse.isPublic,
+                          placeGuideInfo.createdByCurrentUser,
+                          placeGuideInfo.bookmarkedByCurrentUser);
   }
 
   static getUserFromResponse(userResponse) {
@@ -96,17 +83,11 @@ class PlaceGuideRepository {
                   + error);
             alert("Failed to process the data of guides");
           })
-          .then(placeGuideWithCreatorPairs =>
-              PlaceGuideRepository
-                  .buildPlaceGuideDictionaryFromResponse(
-                      placeGuideWithCreatorPairs))
-          .catch(error => {
-            console.log(
-                  "updatePlaceGuides: unable to build placeGuide dictionary: "
-                  + error);
-            alert("Failed to process the data of guides")
-          })
-          .then(placeGuides => thisRepository._placeGuides = placeGuides);
+          .then(placeGuideWithCreatorPairs => function() {
+            thisRepository._placeGuides = PlaceGuideRepository
+                .buildPlaceGuideDictionaryFromResponse(
+                    placeGuideWithCreatorPairs)
+          });
     } else {
       var thisRepository = this;
       return new Promise(function (resolve, reject) {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -245,6 +245,13 @@ body {
     padding-left: 16px;
 }
 
+.place-guide-place-name {
+    font-size: 12px;
+    padding-bottom: 2px;
+    font-style: italic;
+    padding-left: 16px;
+}
+
 .list-place-guide-displayer {
     overflow:hidden; 
     overflow-y:scroll;


### PR DESCRIPTION
#### Issue
In some cases, PlacesService, which was responsible for geocoding(i.e finding the place with all the details corresponding to an ID) failed, and then the place could not be identified.

![image](https://user-images.githubusercontent.com/25320744/93514270-ac6fab00-f92f-11ea-80d3-012cb77bb3b0.png)

#### Solution 
I checked the status of PlacesService, and it was OVER_QUERY_LIMIT. (According to some unofficial documentation, one cannot send more than 10 requests to the Places API for geocoding.) To solve this issue, I reorganized the data based on the remark that I don't need the data from the PlacesService directly after fetching the guides from the server: 

- I need it only when the infowindow of the marker is opened
- or when the infobox in the list is expanded

So instead of doing geocoding directly after fetching, for all guides at once, I do it only on-demand, when a DOM event occurs(when the guide is highlighted or when the infobox is expanded. Both happen on clicks). 

To optimize this solution even more, if for one placeguide geocoding was done, I cache the data that I need(currently, it's only the name of the place) in the Location object, so that on the next event I won't repeat the server request. 

However, to make this solution possible, I had to remove the place name field from the folded placeguide card. Instead, I added it to the expanded placeguide card. 