### PR TITLE
Bug Fix: editing a placeguide with no placeId

### DIFF
--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -77,7 +77,7 @@ function fillFormWithPlaceGuideToEdit() {
     document.getElementById('audioKey').required = false;
     const GET = UrlQueryUtils.getParamsFromQueryString();
     document.getElementById('id').value = GET['placeGuideId'];
-    if(GET['placeId'] !== 'null') {
+    if (GET['placeId'] !== 'null') {
       setFormInputValueOrEmpty(
           document.getElementById('placeId'),
           GET['placeId']);

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -77,14 +77,18 @@ function fillFormWithPlaceGuideToEdit() {
     document.getElementById('audioKey').required = false;
     const GET = UrlQueryUtils.getParamsFromQueryString();
     document.getElementById('id').value = GET['placeGuideId'];
-    setFormInputValueOrEmpty(
-        document.getElementById('placeId'),
-        GET['placeId']);
-    setFormInputValueOrEmpty(
-        new mdc.textField.MDCTextField(document.getElementById('nameInput')),
-        GET['name']);
+    if(GET['placeId'] !== 'undefined' && GET['placeId'] !== 'null') {
+      setFormInputValueOrEmpty(
+          document.getElementById('placeId'),
+          GET['placeId']);
+    }
+    if(GET['name'] !== 'undefined') {
+      setFormInputValueOrEmpty(
+          new mdc.textField.MDCTextField(document.getElementById('nameInput')),
+          GET['name']);
+    }
     document.getElementById('audioPlayer').src = PlaceGuideOnList.getBlobSrc(GET['audioKey']);
-    if (GET['imageKey'] != 'undefined') {
+    if (GET['imageKey'] !== 'undefined') {
       document.getElementById('imagePreview').style.display = 'block';
       document.getElementById('imagePreview').src =
         PlaceGuideOnList.getBlobSrc(GET['imageKey']);
@@ -95,7 +99,7 @@ function fillFormWithPlaceGuideToEdit() {
     } else {
       activateRemoveImageFeature('clear-img-icon', false);
     }
-    if (GET['description'] != 'undefined') {
+    if (GET['description'] !== 'undefined') {
       setFormInputValueOrEmpty(
           new mdc.textField.MDCTextField(document.getElementById('descriptionInput')),
           GET['description']);
@@ -111,7 +115,7 @@ function fillFormWithPlaceGuideToEdit() {
         GET['audioLength']);
     const publicitySwitchControl =
     new mdc.switchControl.MDCSwitch(document.getElementById('publicitySwitch'));
-    if (GET['isPublic'] == 'true') {
+    if (GET['isPublic'] === 'true') {
       publicitySwitchControl.checked = true;
     } else {
       publicitySwitchControl.checked = false;

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -77,7 +77,7 @@ function fillFormWithPlaceGuideToEdit() {
     document.getElementById('audioKey').required = false;
     const GET = UrlQueryUtils.getParamsFromQueryString();
     document.getElementById('id').value = GET['placeGuideId'];
-    if(GET['placeId'] !== 'undefined' && GET['placeId'] !== 'null') {
+    if(GET['placeId'] !== 'null') {
       setFormInputValueOrEmpty(
           document.getElementById('placeId'),
           GET['placeId']);

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -82,11 +82,9 @@ function fillFormWithPlaceGuideToEdit() {
           document.getElementById('placeId'),
           GET['placeId']);
     }
-    if(GET['name'] !== 'undefined') {
-      setFormInputValueOrEmpty(
-          new mdc.textField.MDCTextField(document.getElementById('nameInput')),
-          GET['name']);
-    }
+    setFormInputValueOrEmpty(
+        new mdc.textField.MDCTextField(document.getElementById('nameInput')),
+        GET['name']);
     document.getElementById('audioPlayer').src = PlaceGuideOnList.getBlobSrc(GET['audioKey']);
     if (GET['imageKey'] !== 'undefined') {
       document.getElementById('imagePreview').style.display = 'block';


### PR DESCRIPTION
 This PR solves a bug encountered by a guide with no placeId is edited. 

#### Issue
When a guide with no placeId is edited, after the changes being submitted the guide doesn't show up anymore on the map or on the list. 

#### Reasons
The bug was caused by the fact that geocoding failed for a "null" placeId, despite geocoding not being supposed to start at all for guides with an undefined placeId(a placeId stored as null in the database is returned as undefined to the client-side). 

The key here is that the value in the database was not null, but "null" as a string, because whenever a guide with a null placeid was edited, the null value was trasmitted through the url as a string, and then without any check that "null" string was written as a valid placeId into the form input. This "null" string was then submitted and saved in the database, instead of a null value. 

#### Solution
I added a check for the value transmitted through the url, and wrote it into the form input only if it was not "null"(i.e. the guide has a valid placeId). Otherwise an empty value is kept, which is then interpreted as null on the server-side. 