### PR TITLE
Bug Fix: unauthorized users editing a guide

### DIFF
--- a/src/main/java/com/google/sps/data/PlaceGuideQueryType.java
+++ b/src/main/java/com/google/sps/data/PlaceGuideQueryType.java
@@ -16,6 +16,7 @@ package com.google.sps.data;
 
 /** Specifies the possible form types of queries for PlaceGuides. */
 public enum PlaceGuideQueryType {
+  PLACE_GUIDE_WITH_ID(/* requiresCoordinates= */ false, /* requiresUserIdFromRequest= */ false),
   ALL_PUBLIC(/* requiresCoordinates= */ false, /* requiresUserIdFromRequest= */ false),
   CREATED_ALL(/* requiresCoordinates= */ false, /* requiresUserIdFromRequest= */ false),
   CREATED_PUBLIC(/* requiresCoordinates= */ false, /* requiresUserIdFromRequest= */ false),

--- a/src/main/java/com/google/sps/placeGuideInfo/PlaceGuideInfo.java
+++ b/src/main/java/com/google/sps/placeGuideInfo/PlaceGuideInfo.java
@@ -32,7 +32,7 @@ public class PlaceGuideInfo {
   private boolean createdByCurrentUser;
   private boolean bookmarkedByCurrentUser;
   private static final UserRepository userRepository =
-      UserRepositoryFactory.getUserRepository(RepositoryType.DATASTORE);;
+      UserRepositoryFactory.getUserRepository(RepositoryType.DATASTORE);
 
   /** For production. */
   public PlaceGuideInfo(PlaceGuide placeGuide, String currentUserId) {

--- a/src/main/java/com/google/sps/servlets/PlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/PlaceGuideServlet.java
@@ -74,8 +74,11 @@ public class PlaceGuideServlet extends HttpServlet {
     PlaceGuideQueryType placeGuideQueryType =
         PlaceGuideQueryType.valueOf(placeGuideQueryTypeString);
     if (placeGuideQueryType == PlaceGuideQueryType.PLACE_GUIDE_WITH_ID) {
-      long placeGuideId = request.getParameter(PLACE_GUIDE_ID_PARAMETER);
+      long placeGuideId = Long.parseLong(request.getParameter(PLACE_GUIDE_ID_PARAMETER));
       PlaceGuide placeGuide = placeGuideRepository.getPlaceGuide(placeGuideId);
+      if (placeGuide == null) {
+        throw new IllegalArgumentException("There is no placeguide ith this id: " + placeGuideId);
+      }
       String currentUserId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
       PlaceGuideInfo placeGuideInfo = new PlaceGuideInfo(placeGuide, currentUserId);
       response.setContentType("application/json;");

--- a/src/main/java/com/google/sps/servlets/PlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/PlaceGuideServlet.java
@@ -64,7 +64,8 @@ public class PlaceGuideServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     PlaceGuide placeGuide = getPlaceGuideFromRequest(request);
     placeGuideRepository.savePlaceGuide(placeGuide);
-    response.sendRedirect("/createPlaceGuide.html");
+    response.sendRedirect(
+        String.format("/createPlaceGuide.html?placeGuideId=%d", placeGuide.getId()));
   }
 
   /** Returns the data of the placeguide(s) asked by the user who is currently logged in. */

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -73,52 +73,70 @@ function updateLocation(position, placeId) {
  */
 function fillFormWithPlaceGuideToEdit() {
   if (window.location.search != '') {
-    enableSubmission();
-    document.getElementById('audioKey').required = false;
     const GET = UrlQueryUtils.getParamsFromQueryString();
-    document.getElementById('id').value = GET['placeGuideId'];
-    if (GET['placeId'] !== 'null') {
-      setFormInputValueOrEmpty(
-          document.getElementById('placeId'),
-          GET['placeId']);
-    }
-    setFormInputValueOrEmpty(
-        new mdc.textField.MDCTextField(document.getElementById('nameInput')),
-        GET['name']);
-    document.getElementById('audioPlayer').src = PlaceGuideOnList.getBlobSrc(GET['audioKey']);
-    if (GET['imageKey'] !== 'undefined') {
-      document.getElementById('imagePreview').style.display = 'block';
-      document.getElementById('imagePreview').src =
-        PlaceGuideOnList.getBlobSrc(GET['imageKey']);
-      document.getElementById('no-img-icon')
-          .style.display = 'none';
-      document.getElementById('clear-img-icon').style.display = 'block';
-      activateRemoveImageFeature('clear-img-icon', true);
-    } else {
-      activateRemoveImageFeature('clear-img-icon', false);
-    }
-    if (GET['description'] !== 'undefined') {
-      setFormInputValueOrEmpty(
-          new mdc.textField.MDCTextField(document.getElementById('descriptionInput')),
-          GET['description']);
-    }
-    setFormInputValueOrEmpty(
-        document.getElementById('latitude'),
-        GET['latitude']);
-    setFormInputValueOrEmpty(
-        document.getElementById('longitude'),
-        GET['longitude']);
-    setFormInputValueOrEmpty(
-        new mdc.textField.MDCTextField(document.getElementById('lengthInput')),
-        GET['audioLength']);
-    const publicitySwitchControl =
-    new mdc.switchControl.MDCSwitch(document.getElementById('publicitySwitch'));
-    if (GET['isPublic'] === 'true') {
-      publicitySwitchControl.checked = true;
-    } else {
-      publicitySwitchControl.checked = false;
-    }
-  } else {
-    activateRemoveImageFeature('clear-img-icon', false);
+    var url = new URL('/place-guide-data', document.URL);
+    url.searchParams.append('placeGuideType', "PLACE_GUIDE_WITH_ID");
+    url.searchParams.append('placeGuideId', GET['placeGuideId']);
+    return fetch(url)
+        .catch(error => {
+          console.log("PlaceGuideServlet: failed to fetch: " + error);
+          alert("Failed to load the data of the guide to edit");
+        })
+        .then(response => response.json())
+        .catch(error => {
+          console.log('updatePlaceGuides: failed to convert response to JSON'
+              + error);
+          alert("Failed to process the data of the gudie to edit");
+        })
+        .then(placeGuideWithCreatorPair => {
+          console.log("fetching finished");
+          enableSubmission();
+          document.getElementById('audioKey').required = false;
+        });
   }
+
+  //   if (GET['placeId'] !== 'null') {
+  //     setFormInputValueOrEmpty(
+  //         document.getElementById('placeId'),
+  //         GET['placeId']);
+  //   }
+  //   setFormInputValueOrEmpty(
+  //       new mdc.textField.MDCTextField(document.getElementById('nameInput')),
+  //       GET['name']);
+  //   document.getElementById('audioPlayer').src = PlaceGuideOnList.getBlobSrc(GET['audioKey']);
+  //   if (GET['imageKey'] !== 'undefined') {
+  //     document.getElementById('imagePreview').style.display = 'block';
+  //     document.getElementById('imagePreview').src =
+  //       PlaceGuideOnList.getBlobSrc(GET['imageKey']);
+  //     document.getElementById('no-img-icon')
+  //         .style.display = 'none';
+  //     document.getElementById('clear-img-icon').style.display = 'block';
+  //     activateRemoveImageFeature('clear-img-icon', true);
+  //   } else {
+  //     activateRemoveImageFeature('clear-img-icon', false);
+  //   }
+  //   if (GET['description'] !== 'undefined') {
+  //     setFormInputValueOrEmpty(
+  //         new mdc.textField.MDCTextField(document.getElementById('descriptionInput')),
+  //         GET['description']);
+  //   }
+  //   setFormInputValueOrEmpty(
+  //       document.getElementById('latitude'),
+  //       GET['latitude']);
+  //   setFormInputValueOrEmpty(
+  //       document.getElementById('longitude'),
+  //       GET['longitude']);
+  //   setFormInputValueOrEmpty(
+  //       new mdc.textField.MDCTextField(document.getElementById('lengthInput')),
+  //       GET['audioLength']);
+  //   const publicitySwitchControl =
+  //   new mdc.switchControl.MDCSwitch(document.getElementById('publicitySwitch'));
+  //   if (GET['isPublic'] === 'true') {
+  //     publicitySwitchControl.checked = true;
+  //   } else {
+  //     publicitySwitchControl.checked = false;
+  //   }
+  // } else {
+  //   activateRemoveImageFeature('clear-img-icon', false);
+  // }
 }

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -84,9 +84,9 @@ function fillFormWithPlaceGuideToEdit() {
         })
         .then(response => response.json())
         .catch(error => {
-          console.log('updatePlaceGuides: failed to convert response to JSON'
+          console.log('fillFormWithPlaceGuideToEdit: failed to convert response to JSON'
               + error);
-          alert("Failed to process the data of the gudie to edit");
+          alert("Failed to process the data of the guide to edit");
         })
         .then(placeGuideWithCreatorPair => {
           console.log("fetching finished");

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -6,7 +6,7 @@ function setUpCreatePlaceGuideForm() {
       'CREATE_PLACE_GUIDE_FORM', 'createPlaceGuideForm');
   activatePreviewFeature();
   styleInputs();
-  if(window.location.search !== '') {
+  if (window.location.search !== '') {
     fillFormWithPlaceGuideToEdit();
   } else {
     activateRemoveImageFeature('clear-img-icon', false);
@@ -77,22 +77,22 @@ function updateLocation(position, placeId) {
  */
 function fillFormWithPlaceGuideToEdit() {
   const GET = UrlQueryUtils.getParamsFromQueryString();
-  var url = new URL('/place-guide-data', document.URL);
+  const url = new URL('/place-guide-data', document.URL);
   url.searchParams.append('placeGuideType', "PLACE_GUIDE_WITH_ID");
   url.searchParams.append('placeGuideId', GET['placeGuideId']);
   return fetch(url)
-      .catch(error => {
+      .catch((error) => {
         console.log("PlaceGuideServlet: failed to fetch: " + error);
         alert("Failed to load the data of the guide to edit");
       })
-      .then(response => response.json())
-      .catch(error => {
+      .then((response) => response.json())
+      .catch((error) => {
         console.log('fillFormWithPlaceGuideToEdit: ' +
-            'failed to convert response to JSON'
-            + error);
+            'failed to convert response to JSON' +
+             error);
         alert("Failed to process the data of the guide to edit");
       })
-      .then(placeGuideInfo => {
+      .then((placeGuideInfo) => {
         console.log("fetching finished");
         const placeGuideToEdit =
             PlaceGuideRepository.

--- a/src/main/webapp/forms/placeGuideForm.js
+++ b/src/main/webapp/forms/placeGuideForm.js
@@ -115,7 +115,7 @@ function fillFormWithPlaceGuideData(placeGuide) {
       placeGuide.name);
   document.getElementById('audioPlayer').src =
       PlaceGuideOnList.getBlobSrc(placeGuide.audioKey);
-  if (placeGuide.imgKey !== 'undefined') {
+  if (placeGuide.imgKey !== undefined) {
     document.getElementById('imagePreview').style.display = 'block';
     document.getElementById('imagePreview').src =
       PlaceGuideOnList.getBlobSrc(placeGuide.imgKey);
@@ -126,7 +126,7 @@ function fillFormWithPlaceGuideData(placeGuide) {
   } else {
     activateRemoveImageFeature('clear-img-icon', false);
   }
-  if (placeGuide.description !== 'undefined') {
+  if (placeGuide.description !== undefined) {
     setFormInputValueOrEmpty(
         new mdc.textField.MDCTextField(
             document.getElementById('descriptionInput')),

--- a/src/main/webapp/placeGuides/Location.js
+++ b/src/main/webapp/placeGuides/Location.js
@@ -24,7 +24,7 @@ class Location {
         resolve(thisPlaceName);
       });
     } else {
-      if (this._placeId == undefined) {
+      if (this._placeId === undefined) {
         return new Promise(function(resolve, reject) {
           resolve(undefined);
         });

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -69,12 +69,6 @@ class PlaceGuideOnList {
   static generateQueryString(placeGuideProperties) {
     const query = encodeURIComponent("placeGuideId") + "=" +
         encodeURIComponent(placeGuideProperties.placeGuideId);
-    // const query = Object.keys(placeGuideProperties)
-    //     .map(function(propertyKey) {
-    //       return encodeURIComponent(propertyKey) + '=' +
-    //           encodeURIComponent(placeGuideProperties[propertyKey]);
-    //     })
-    //     .join('&');
     return query;
   }
 

--- a/src/main/webapp/placeGuides/PlaceGuideOnList.js
+++ b/src/main/webapp/placeGuides/PlaceGuideOnList.js
@@ -67,12 +67,14 @@ class PlaceGuideOnList {
   }
 
   static generateQueryString(placeGuideProperties) {
-    const query = Object.keys(placeGuideProperties)
-        .map(function(propertyKey) {
-          return encodeURIComponent(propertyKey) + '=' +
-              encodeURIComponent(placeGuideProperties[propertyKey]);
-        })
-        .join('&');
+    const query = encodeURIComponent("placeGuideId") + "=" +
+        encodeURIComponent(placeGuideProperties.placeGuideId);
+    // const query = Object.keys(placeGuideProperties)
+    //     .map(function(propertyKey) {
+    //       return encodeURIComponent(propertyKey) + '=' +
+    //           encodeURIComponent(placeGuideProperties[propertyKey]);
+    //     })
+    //     .join('&');
     return query;
   }
 

--- a/src/test/java/com/google/sps/PlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/PlaceGuideServletTest.java
@@ -334,6 +334,45 @@ public final class PlaceGuideServletTest {
   }
 
   @Test
+  public void doGet_getPlaceGuide_currentUserOwnsGuide() throws IOException {
+    saveUser(userC);
+    datastore.put(getEntityFromPlaceGuide(testInnerPublicPlaceGuideC));
+    setupDoGetMockRequest(
+        PlaceGuideQueryType.PLACE_GUIDE_WITH_ID, SOUTH_WEST_CORNER, NORTH_EAST_CORNER);
+    when(request.getParameter(PlaceGuideServlet.PLACE_GUIDE_ID_PARAMETER))
+        .thenReturn(String.valueOf(testInnerPublicPlaceGuideC.getId()));
+    PlaceGuideServlet placeGuideServlet = new PlaceGuideServlet(blobstoreService, blobInfoFactory);
+    placeGuideServlet.doGet(request, response);
+
+    printWriter.flush();
+    Gson gson = new Gson();
+    PlaceGuideInfo result =
+        new GsonBuilder().create().fromJson(stringWriter.toString(), PlaceGuideInfo.class);
+    PlaceGuideInfo expected = new PlaceGuideInfo(testInnerPublicPlaceGuideC, userC, true, false);
+    assertTrue(placeGuideInfoEquals(expected, result));
+  }
+
+  @Test
+  public void doGet_getPlaceGuide_currentUserDoesntOwnGuide() throws IOException {
+    saveUser(userC);
+    saveUser(userD);
+    datastore.put(getEntityFromPlaceGuide(testInnerPublicPlaceGuideD));
+    setupDoGetMockRequest(
+        PlaceGuideQueryType.PLACE_GUIDE_WITH_ID, SOUTH_WEST_CORNER, NORTH_EAST_CORNER);
+    when(request.getParameter(PlaceGuideServlet.PLACE_GUIDE_ID_PARAMETER))
+        .thenReturn(String.valueOf(testInnerPublicPlaceGuideD.getId()));
+    PlaceGuideServlet placeGuideServlet = new PlaceGuideServlet(blobstoreService, blobInfoFactory);
+    placeGuideServlet.doGet(request, response);
+
+    printWriter.flush();
+    Gson gson = new Gson();
+    PlaceGuideInfo result =
+        new GsonBuilder().create().fromJson(stringWriter.toString(), PlaceGuideInfo.class);
+    PlaceGuideInfo expected = new PlaceGuideInfo(testInnerPublicPlaceGuideD, userD, false, false);
+    assertTrue(placeGuideInfoEquals(expected, result));
+  }
+
+  @Test
   public void doGet_getAllPublicPlaceGuides_placeGuideExists_returnPlaceGuides()
       throws IOException {
     saveUser(userC);


### PR DESCRIPTION
### This PR is intended to solve a bug of users being able to edit guides which are not created by them. 

 #### Issue
Although the "edit guide" button was accessible only for the creator of a given guide, the data of the guide was then transmitted though the url(when switching to the createPlaceGuide page with the scope of editing an existing guide), and then any user could edit that guide if they had the link to it, even if they were not authorised(i.e. they are not the creators of the guide). 

#### Solution
1. Client-side changes
Instead of passing all of the data through the url, I modified the code so that only the ID of the guide is transmitted. On the createPlaceGuide page, if an ID is present in the url, then the data of the corresponding guide is fetched from the server and the form is filled with that data. 

2. Server-side changes
To enable getting the data of one particular guide, I added support for a new query type in PlaceGuideServlet: PLACE_GUIDE_WITH_ID.  I also added some tests for the new query. 

Additionally, I now let the user continue editing a guide's data after submission, simply by redirecting to the corresponding url (createPlaceGuide page with the ID parameter of the previously edited guide). This improves the user experience, because the user can see that the changes are indeed saved, and they can also continue editing if they are not satisfied with the result. 
