### PR TITLE
Bug Fix: bookmark limit

### DIFF
--- a/src/main/java/com/google/sps/placeGuide/repository/impl/DatastorePlaceGuideRepository.java
+++ b/src/main/java/com/google/sps/placeGuide/repository/impl/DatastorePlaceGuideRepository.java
@@ -236,7 +236,7 @@ public class DatastorePlaceGuideRepository implements PlaceGuideRepository {
         Entity placeGuideEntity = datastore.get(placeGuideEntityKey);
         bookmarkedPlaceGuides.add(getPlaceGuideFromEntity(placeGuideEntity));
       } catch (EntityNotFoundException err) {
-        System.out.println("Place Guide does not exist anymore.");
+        userRepository.removeBookmarkedPlaceGuide(placeGuideId, userId);
       }
     }
     return bookmarkedPlaceGuides;

--- a/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
+++ b/src/main/java/com/google/sps/servlets/BookmarkPlaceGuideServlet.java
@@ -4,6 +4,8 @@ import com.google.appengine.api.datastore.*;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
 import com.google.sps.data.RepositoryType;
+import com.google.sps.placeGuide.repository.PlaceGuideRepository;
+import com.google.sps.placeGuide.repository.PlaceGuideRepositoryFactory;
 import com.google.sps.user.User;
 import com.google.sps.user.repository.UserRepository;
 import com.google.sps.user.repository.UserRepositoryFactory;
@@ -25,6 +27,8 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
 
   private final UserRepository userRepository =
       UserRepositoryFactory.getUserRepository(RepositoryType.DATASTORE);
+  private final PlaceGuideRepository placeGuideRepository =
+      PlaceGuideRepositoryFactory.getPlaceGuideRepository(RepositoryType.DATASTORE);
 
   private enum BookmarkPlaceGuideQueryType {
     BOOKMARK,
@@ -60,11 +64,8 @@ public class BookmarkPlaceGuideServlet extends HttpServlet {
     String userId = UserServiceFactory.getUserService().getCurrentUser().getUserId();
     switch (bookmarkPlaceGuideQueryType) {
       case BOOKMARK:
-        User user = userRepository.getUser(userId);
-        if (user == null) {
-          throw new IllegalStateException("The current user does not exist in the database!");
-        }
-        if (user.canBookmarkAnotherPlaceGuide()) {
+        if (placeGuideRepository.getBookmarkedPlaceGuides(userId).size()
+            < User.MAX_NO_BOOKMARKED_PLACEGUIDES) {
           userRepository.bookmarkPlaceGuide(placeGuideId, userId);
           return true;
         } else {

--- a/src/main/java/com/google/sps/user/User.java
+++ b/src/main/java/com/google/sps/user/User.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 /** Stores the data related to one user. */
 public class User {
-  private static final int MAX_NO_BOOKMARKED_PLACEGUIDES = 25;
+  public static final int MAX_NO_BOOKMARKED_PLACEGUIDES = 25;
   private final String id;
   private final String email;
   private final boolean publicPortfolio;
@@ -125,10 +125,6 @@ public class User {
 
   public Set<Long> getBookmarkedPlaceGuidesIds() {
     return Collections.unmodifiableSet(bookmarkedPlaceGuidesIds);
-  }
-
-  public boolean canBookmarkAnotherPlaceGuide() {
-    return this.bookmarkedPlaceGuidesIds.size() < MAX_NO_BOOKMARKED_PLACEGUIDES;
   }
 
   @Override

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -118,6 +118,7 @@ public final class BookmarkPlaceGuideServletTest {
     Boolean successfulBookmark = gson.fromJson(sw.toString(), Boolean.class);
     assertTrue(successfulBookmark);
     assertTrue(userHasBookmarkedThePlaceGuide(ID_D, toBookmarkGuide.getId()));
+    assertFalse(userHasBookmarkedThePlaceGuide(ID_D, 25));
   }
 
   @Test

--- a/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
+++ b/src/test/java/com/google/sps/BookmarkPlaceGuideServletTest.java
@@ -45,6 +45,7 @@ import org.junit.runners.JUnit4;
 public final class BookmarkPlaceGuideServletTest {
   private Map<String, Object> attributeToValue = new HashMap<>();
   private LocalServiceTestHelper helper;
+  private DatastoreService datastore;
 
   private HttpServletRequest request;
   private HttpServletResponse response;
@@ -62,6 +63,7 @@ public final class BookmarkPlaceGuideServletTest {
 
     request = mock(HttpServletRequest.class);
     response = mock(HttpServletResponse.class);
+    datastore = DatastoreServiceFactory.getDatastoreService();
   }
 
   @Test
@@ -69,6 +71,7 @@ public final class BookmarkPlaceGuideServletTest {
       throws IOException, EntityNotFoundException {
     setupCurrentUserIdInHelper(ID_A);
     saveUser(userA);
+    savePlaceGuidesWithIds(userA.getBookmarkedPlaceGuidesIds());
     savePlaceGuide(toBookmarkGuide);
     setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
     BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
@@ -85,6 +88,7 @@ public final class BookmarkPlaceGuideServletTest {
       throws IOException, EntityNotFoundException {
     setupCurrentUserIdInHelper(ID_B);
     saveUser(userB);
+    savePlaceGuidesWithIds(userB.getBookmarkedPlaceGuidesIds());
     savePlaceGuide(toBookmarkGuide);
     setupRequestandResponse("Bookmark", toBookmarkGuide.getId());
     BookmarkPlaceGuideServlet boookmarkPlaceGuideServlet = new BookmarkPlaceGuideServlet();
@@ -100,6 +104,7 @@ public final class BookmarkPlaceGuideServletTest {
   public void doGet_unbookmark_succesfulUnbookmarking()
       throws IOException, EntityNotFoundException {
     setupCurrentUserIdInHelper(ID_C);
+    savePlaceGuidesWithIds(userC.getBookmarkedPlaceGuidesIds());
     saveUser(userC);
     savePlaceGuide(toBookmarkGuide);
     setupRequestandResponse("Unbookmark", toBookmarkGuide.getId());
@@ -122,6 +127,35 @@ public final class BookmarkPlaceGuideServletTest {
     attributeToValue.put("com.google.appengine.api.users.UserService.user_id_key", (Object) userId);
     helper.setEnvAttributes(attributeToValue);
     helper.setUp();
+  }
+
+  private void savePlaceGuidesWithIds(Set<Long> IDs) {
+    for (Long id : IDs) {
+      datastore.put(getEntityFromPlaceGuide(new PlaceGuide.Builder(id, "", "", "", null).build()));
+    }
+  }
+
+  private Entity getEntityFromPlaceGuide(PlaceGuide placeGuide) {
+    Entity placeGuideEntity =
+        new Entity(DatastorePlaceGuideRepository.ENTITY_KIND, placeGuide.getId());
+    placeGuideEntity.setProperty(DatastorePlaceGuideRepository.NAME_PROPERTY, placeGuide.getName());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.AUDIO_KEY_PROPERTY, placeGuide.getAudioKey());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.CREATOR_ID_PROPERTY, placeGuide.getCreatorId());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.IS_PUBLIC_PROPERTY, placeGuide.isPublic());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.PLACE_ID_PROPERTY, placeGuide.getPlaceId());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.COORDINATE_PROPERTY, placeGuide.getCoordinate());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.DESCRIPTION_PROPERTY, placeGuide.getDescription());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.LENGTH_PROPERTY, placeGuide.getLength());
+    placeGuideEntity.setProperty(
+        DatastorePlaceGuideRepository.IMAGE_KEY_PROPERTY, placeGuide.getImageKey());
+    return placeGuideEntity;
   }
 
   // Users data.


### PR DESCRIPTION
#### Context
The user is allowed to bookmark only 25 guides at most. 

#### Issue
Sometimes the user gets the message that they already reached the limit despite of not seeing 25 guides on the bookmarked placeguides page. 

#### Reason
Given that guides are deleted in a "lazy way"(i.e. the guide entity is deleted from the database, but the ID is not deleted from the set of bookmarked guides for all the users), and when checking if bookmarking is allowed, only the size of this set was checked, the previously deleted guides were also counted in. 

#### Solution
I count the existing placeGuides only, and ignore the deleted ones, when deciding if a user can bookmark a new guide or not.
Additionally, if any of the guides in the set does not exist, I remove it from the set in the database.  